### PR TITLE
Added configuration of stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 1
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 1
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - feature
+# Label to use when marking an issue as stale
+staleLabel: auto-stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue/pull request has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue/pull request has been automatically marked as closed because it has not had
+  recent activity.


### PR DESCRIPTION
Added https://probot.github.io/apps/stale/ and its configuration. This configuration will automatically add label as auto-stale if there is no activity on pull request/Issue for N day. It will close pull request/issue after inactivity of M days.
For testing configured N and M and 1 day for now. It can be updated in configuration.