### PR TITLE
Added OS version in Custom Build

### DIFF
--- a/jenkins/custom-ci/centos-7.8-custom-ci-jenkinsfile
+++ b/jenkins/custom-ci/centos-7.8-custom-ci-jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 		release_dir="/mnt/bigstorage/releases/cortx"
 		integration_dir="$release_dir/github/integration-custom-ci/release/$os_version"
 		components_dir="$release_dir/components/github/custom-ci/release/$os_version"
-		release_tag="custom-build-$BUILD_ID"
+		release_tag="custom-build-$os_version-$BUILD_ID"
 		passphrase = credentials('rpm-sign-passphrase')
 		thrid_party_dir="/mnt/bigstorage/releases/cortx/third-party-deps/centos/centos-7.8.2003"
 		python_deps="/mnt/bigstorage/releases/cortx/third-party-deps/python-packages"

--- a/jenkins/custom-ci/custom-ci-jenkinsfile
+++ b/jenkins/custom-ci/custom-ci-jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 		release_dir="/mnt/bigstorage/releases/cortx"
         integration_dir="$release_dir/github/integration-custom-ci/release/$os_version"
         components_dir="$release_dir/components/github/custom-ci/release/$os_version"
-        release_tag="custom-build-$BUILD_ID"
+        release_tag="custom-build-$os_version-$BUILD_ID
         passphrase = credentials('rpm-sign-passphrase')
 		thrid_party_dir="/mnt/bigstorage/releases/cortx/third-party-deps/rhel/rhel-7.7.1908/"
 		python_deps="/mnt/bigstorage/releases/cortx/third-party-deps/python-packages"


### PR DESCRIPTION
Currently both CentOS and RHEL Custom builds are located at same location. 
e.g. 

http://cortx-storage.colo.seagate.com/releases/cortx/github/integration-custom-ci/release/custom-build-544/
http://cortx-storage.colo.seagate.com/releases/cortx/github/integration-custom-ci/release/custom-build-14/

Added OS version in name field. 