### PR TITLE
Fix error in csm job.

### DIFF
--- a/jenkins/internal-ci/centos-7.8.2003/main/csm-web.groovy
+++ b/jenkins/internal-ci/centos-7.8.2003/main/csm-web.groovy
@@ -90,7 +90,7 @@ pipeline {
 			steps {
 				script { build_stage = env.STAGE_NAME }
 				sh label: 'Tag last_successful', script: '''pushd $build_upload_dir/
-                    test --L $build_upload_dir/last_successful && rm -f last_successful
+                    test -L $build_upload_dir/last_successful && rm -f last_successful
                     ln -s $build_upload_dir/$BUILD_NUMBER last_successful
                     popd
                 '''


### PR DESCRIPTION
Fix error in CSM job - 

```
19:22:23  /mnt/bigstorage/releases/cortx/components/github/main/centos-7.8.2003/dev/csm-web /tmp/workspace/Cortx-Main/centos-7.8.2003/CSM-Web
19:22:23  + test --L /mnt/bigstorage/releases/cortx/components/github/main/centos-7.8.2003/dev/csm-web/last_successful
19:22:23  /tmp/workspace/Cortx-Main/centos-7.8.2003/CSM-Web@tmp/durable-31567286/script.sh: line 2: test: --L: unary operator expected
19:22:23  + ln -s /mnt/bigstorage/releases/cortx/components/github/main/centos-7.8.2003/dev/csm-web/17 last_successful
19:22:23  + popd
```