### PR TITLE
Update build command for cortx-py-utils

### DIFF
--- a/jenkins/internal-ci/centos-7.8.2003/main/cortx-py-utils.groovy
+++ b/jenkins/internal-ci/centos-7.8.2003/main/cortx-py-utils.groovy
@@ -46,7 +46,7 @@ pipeline {
 				sh label: 'Build', script: '''
 				yum install python36-devel -y
 				pushd py-utils
-				python3 setup.py bdist_rpm --post-install utils-post-install --pre-uninstall utils-pre-uninstall --release="${BUILD_NUMBER}_$(git rev-parse --short HEAD)"
+				python3.6 setup.py bdist_rpm --post-install utils-post-install --pre-uninstall utils-pre-uninstall --post-uninstall utils-post-uninstall -release="${BUILD_NUMBER}_$(git rev-parse --short HEAD)"
 				popd
 				
 				./statsd-utils/jenkins/build.sh -b $BUILD_NUMBER

--- a/jenkins/internal-ci/centos-7.8.2003/stable/cortx-py-utils.groovy
+++ b/jenkins/internal-ci/centos-7.8.2003/stable/cortx-py-utils.groovy
@@ -39,7 +39,7 @@ pipeline {
 				sh label: 'Build', script: '''
 				yum install python36-devel -y
 				pushd py-utils
-				python3 setup.py bdist_rpm --post-install utils-post-install --pre-uninstall utils-pre-uninstall --release="${BUILD_NUMBER}_$(git rev-parse --short HEAD)"
+				python3.6 setup.py bdist_rpm --post-install utils-post-install --pre-uninstall utils-pre-uninstall --post-uninstall utils-post-uninstall -release="${BUILD_NUMBER}_$(git rev-parse --short HEAD)"
 				popd
 				
 				./statsd-utils/jenkins/build.sh -b $BUILD_NUMBER


### PR DESCRIPTION
After recent code changes, the build command for cortx-py-utils rpm is changed. The new command is as below:
`python3.6 setup.py bdist_rpm --post-install utils-post-install --pre-uninstall utils-pre-uninstall --post-uninstall utils-post-uninstall`
