### PR TITLE
EOS-18500 Handling 3rd party python packages in build environment

### DIFF
--- a/jenkins/internal-ci/centos-7.8.2003/main/cortx-ha.groovy
+++ b/jenkins/internal-ci/centos-7.8.2003/main/cortx-ha.groovy
@@ -54,6 +54,7 @@ EOF
 			'''		
 			}
 		}
+		
 		stage('Install Dependencies') {
 			steps {
 				script { build_stage = env.STAGE_NAME }

--- a/jenkins/internal-ci/centos-7.8.2003/stable/cortx-ha
+++ b/jenkins/internal-ci/centos-7.8.2003/stable/cortx-ha
@@ -36,6 +36,25 @@ pipeline {
 				}
 			}
 		}
+
+		// Install third-party dependencies. This needs to be removed once components move away from self-contained binaries 
+	    stage('Install python packages') {
+			steps {
+        	    script { build_stage = env.STAGE_NAME }
+				sh label: '', script: '''
+					yum erase python36-PyYAML -y
+					cat <<EOF >>/etc/pip.conf
+[global]
+timeout: 60
+index-url: http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/python-packages-2.0.0-latest/
+trusted-host: cortx-storage.colo.seagate.com
+EOF
+					pip3 install -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/requirements.txt
+					rm -rf /etc/pip.conf
+			'''		
+			}
+		}
+
 	
 		stage('Install Dependencies') {
 			steps {


### PR DESCRIPTION
Need to remove /etc/pip.conf as a few of build dependency python packages not available in the local repo. 