### PR TITLE
Codeowner test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,5 @@
 # These owners will be the default owners for everything in the repo.
 *       @shailesh-vaidya
 
-/scripts/third-party-rpm/*.txt        @gowthamchinna
+# Added additional code-owners for cortx-prereq package
+/scripts/third-party-rpm/*.txt        @johnbent @ujjwalpl @shailesh-vaidya


### PR DESCRIPTION
Add @johnbent and @ujjwalpl  as code-owners for cortx-prereq package reviewers. Any PR for modification of python-requirements.txt or third-party-rpms.txt will be need review from additional code owners. 

Example PR - https://github.com/Seagate/cortx-re/pull/312 