### PR TITLE
Use updated /rpms/s3test/buildrpm.sh command

### DIFF
--- a/docker/cortx-build/Makefile
+++ b/docker/cortx-build/Makefile
@@ -114,7 +114,7 @@ _s3_build:
 		export build_number=${BUILD_ID} && \
 		./rpms/s3/buildrpm.sh -S ${RELEASE_VERSION} -G $$(git rev-parse --short HEAD) && \
 		./rpms/s3iamcli/buildrpm.sh -S ${RELEASE_VERSION} -G $$(git rev-parse --short HEAD) && \
-		./rpms/s3test/buildrpm.sh -P $PWD && \
+		./rpms/s3test/buildrpm.sh -S ${RELEASE_VERSION} -G $$(git rev-parse --short HEAD) && \
 		rm -rf {RPM_DIR}/cortx-s3*.rpm && \
 		mv /root/rpmbuild/RPMS/x86_64/*.rpm ${RPM_DIR} && \
        	mv /root/rpmbuild/RPMS/noarch/*.rpm ${RPM_DIR} && \


### PR DESCRIPTION
Accommodate changes done in EOS-19369 cortx-s3server-test rpm build script does not work with -G option.