### PR TITLE
EOS-18740 Hare CI: Write a VM cleanup script

### DIFF
--- a/jenkins/internal-ci/centos-7.8.2003/pr/component_test/hare-premerge.groovy
+++ b/jenkins/internal-ci/centos-7.8.2003/pr/component_test/hare-premerge.groovy
@@ -68,9 +68,7 @@ pipeline {
                     def remote = getTestMachine(VM_FQDN)
                     def commandResult = sshCommand remote: remote, command: """
                         echo "Clean up VM before use"
-                        yum remove cortx-hare -y
-                        yum remove cortx-motr{,-devel} -y
-                        yum remove consul -y
+                        yum remove cortx-hare cortx-motr{,-devel} consul -y 
                         rm -rf /var/crash/* /var/log/seagate/* /var/log/hare/* /var/log/motr/* /var/lib/hare/* /var/motr/* /etc/motr/*
                         rm -rf /root/.cache/dhall* /root/rpmbuild
                         """


### PR DESCRIPTION
Added VM cleanup steps in VM prepare stage.
Added post stage in pipeline.

Signed-off-by: Parikshit Dharmale <parikshit.dharmale@seagate.com>

VM-reset script which does VM snapshot revert is having issue of VM getting stuck on power on and script getting timed out. 
So now instead of snapshot revert VM cleanup is used to clean up the dirs and configs before starting premerge tests.