### PR TITLE
EOS-19471: Update third-party-rpms.txt

### DIFF
--- a/scripts/third-party-rpm/third-party-rpms.txt
+++ b/scripts/third-party-rpm/third-party-rpms.txt
@@ -3,7 +3,6 @@ attr
 compat-lua-libs
 consul >= 1.7.0, consul < 1.10.0
 corosync
-elasticsearch-oss == 6.8.8
 facter
 fence-agents-ipmilan
 findutils
@@ -16,7 +15,6 @@ hdparm == 9.43
 hiredis
 ipmitool == 1.8.18
 jq
-kibana-oss == 6.8.8
 libaio
 libedit
 libxml2
@@ -24,6 +22,8 @@ libyaml
 log4cxx_cortx
 log4cxx_cortx-devel
 lshw == B.02.18
+opendistroforelasticsearch == 1.12.0
+opendistroforelasticsearch-kibana == 1.12.0
 openldap-clients
 openldap-servers
 openssl


### PR DESCRIPTION
Signed-off-by: Puja Mudaliar puja.mudaliar@seagate.com


https://jts.seagate.com/browse/EOS-19471
Tanuja Shinde added a comment - 29/Apr/21 7:02 AM - edited
Gowthaman Chinnathambi Shailesh Vaidya Puja Mudaliar Installing and configuring with below path worked fine:
yum install yum-utils -y
yum-config-manager --add-repo http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/custom-deps/csm/yum install opendistroforelasticsearch-1.12.0 opendistroforelasticsearch-kibana-1.12.0 -y

Please add these packages at below location by replacing the current elasticsearch rpm:

http://cortx-storage.colo.seagate.com/releases/cortx/github/main/centos-7.8.2003/1082/prod/3rd_party/commons/elasticsearch/

 and make sure to remove elasticsearch dependency from : https://github.com/Seagate/cortx-re/blob/main/scripts/third-party-rpm/third-party-rpms.txt and replace it with opendistroforelasticsearch-1.12.0