### PR TITLE
Add REQUIRES section to RELEASE.INFO

### DIFF
--- a/jenkins/custom-ci/centos-7.8.2003/custom-ci.groovy
+++ b/jenkins/custom-ci/centos-7.8.2003/custom-ci.groovy
@@ -322,7 +322,7 @@ pipeline {
 			steps {
                 script { build_stage = env.STAGE_NAME }
                 
-				checkout([$class: 'GitSCM', branches: [[name: 'upgrade-iso-patch-1']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'AuthorInChangelog']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', url: 'https://github.com/shailesh-vaidya/cortx-re']]])
+				checkout([$class: 'GitSCM', branches: [[name: 'main']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'AuthorInChangelog']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', url: 'https://github.com/Seagate/cortx-re']]])
                 
                 sh label: 'Generate Key', script: '''
                     set +x


### PR DESCRIPTION
Added REQUIRES section to RELEASE.INFO. 

Refer - https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/284099843/CORTX+ISO+Package+Structure 

Component Dependency details are fetched from - https://github.com/Seagate/cortx-re/blob/main/scripts/versioning/compatibility.info

RELEASE.INFO will be as below,

```
---
NAME: "CORTX"
VERSION: "2.0.0"
BRANCH: "custom-ci"
THIRD_PARTY_VERSION: "centos-7.8.2003-2.0.0-8"
BUILD: "94"
OS: "CentOS Linux release 7.8.2003 (Core)"
DATETIME: "29-Jun-2021 16:10 UTC"
KERNEL: "3.10.0_1127.el7"
REQUIRES:
    - CORTX >= 2.0.0
    - cortx-motr >= 2.0.0-0
    - cortx-s3server >= 2.0.0-0
    - cortx-hare >= 2.0.0-0
    - cortx-py-utils >= 2.0.0-0
    - cortx-csm_agent >= 2.0.0-0
    - cortx-csm_web >= 2.0.0-0
    - cortx-sspl >= 2.0.0-0
    - cortx-ha >= 2.0.0-0
    - cortx-prvsnr >= 2.0.0-0
COMPONENTS:
    - "cortx-cli-1.0.0-94_1e29362d.x86_64.rpm"
    - "cortx-csm_agent-1.0.0-94_1e29362d.x86_64.rpm"
    - "cortx-csm_web-1.0.0-94_fb57367.x86_64.rpm"
    - "cortx-ha-2.0.0-94_81352a3.x86_64.rpm"
    - "cortx-hare-2.0.0-94_git57570d5.el7.x86_64.rpm"
    - "cortx-hare-debuginfo-2.0.0-94_git57570d5.el7.x86_64.rpm"
    - "cortx-libsspl_sec-2.0.0-94_git39317f60.el7.x86_64.rpm"
    - "cortx-libsspl_sec-debuginfo-2.0.0-94_git39317f60.el7.x86_64.rpm"
    - "cortx-libsspl_sec-method_none-2.0.0-94_git39317f60.el7.x86_64.rpm"
    - "cortx-motr-2.0.0-94_gitb09b81d9_3.10.0_1127.el7.x86_64.rpm"
    - "cortx-motr-debuginfo-2.0.0-94_gitb09b81d9_3.10.0_1127.el7.x86_64.rpm"
    - "cortx-motr-ivt-2.0.0-94_gitb09b81d9_3.10.0_1127.el7.x86_64.rpm"
    - "cortx-prereq-2.0.0-94_git90c6548_el7.x86_64.rpm"
    - "cortx-prvsnr-2.0.0-94_git818b6602_el7.x86_64.rpm"
    - "cortx-py-utils-2.0.0-3529_8625847.noarch.rpm"
    - "cortx-s3iamcli-2.0.0-94_git7f57ba91.noarch.rpm"
    - "cortx-s3server-2.0.0-94_git7f57ba91_el7.x86_64.rpm"
    - "cortx-s3server-debuginfo-2.0.0-94_git7f57ba91_el7.x86_64.rpm"
    - "cortx-s3-test-2.0.0-94_git7f57ba91.noarch.rpm"
    - "cortx-sspl-2.0.0-94_git39317f60.el7.noarch.rpm"
    - "python36-cortx-prvsnr-2.0.53-94_git818b6602.x86_64.rpm"
    - "stats_utils-2.0.0-3529_8625847.x86_64.rpm"
    - "uds-pyi-1.3.0-1.r10.el7.x86_64.rpm"
    - "udx-discovery-0.1.2-3.el7.x86_64.rpm"
```