### PR TITLE
EOS-22041 - Adhoc Increased s3-premerge timeout to 6 Hours

### DIFF
--- a/jenkins/internal-ci/centos-7.8.2003/pr/component_test/s3server-premerge.groovy
+++ b/jenkins/internal-ci/centos-7.8.2003/pr/component_test/s3server-premerge.groovy
@@ -8,7 +8,7 @@ pipeline {
 
 	options {
 		timestamps() 
-        timeout(time: 180, unit: 'MINUTES')
+	        timeout(time: 360, unit: 'MINUTES')
 	}
 
     triggers { 


### PR DESCRIPTION
Increased s3-pre-merge timeout to 6 Hours as requested by the S3 team.