### PR TITLE
EOS-24387 : Restrict concurrent jenkins builds for deployments

### DIFF
--- a/jenkins/deployment/vm_deployment/cortx_stack/cortx_factory_deploy_vm_1n.groovy
+++ b/jenkins/deployment/vm_deployment/cortx_stack/cortx_factory_deploy_vm_1n.groovy
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
+properties([[$class: 'ThrottleJobProperty', categories: [], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 5, maxConcurrentTotal: 5, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'project']])
 pipeline { 
     agent {
         node {
@@ -46,7 +47,6 @@ pipeline {
     options {
         timeout(time: 180, unit: 'MINUTES')
         timestamps()
-        disableConcurrentBuilds()
         ansiColor('xterm') 
         buildDiscarder(logRotator(numToKeepStr: "30"))
     }

--- a/jenkins/deployment/vm_deployment/cortx_stack/cortx_factory_deploy_vm_3n.groovy
+++ b/jenkins/deployment/vm_deployment/cortx_stack/cortx_factory_deploy_vm_3n.groovy
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
+properties([[$class: 'ThrottleJobProperty', categories: [], limitOneJobWithMatchingParams: true, maxConcurrentPerNode: 5, maxConcurrentTotal: 5, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'project']])
 pipeline { 
     agent {
         node {
@@ -51,7 +52,6 @@ pipeline {
     options {
         timeout(time: 180, unit: 'MINUTES')
         timestamps()
-        disableConcurrentBuilds()
         ansiColor('xterm') 
         buildDiscarder(logRotator(numToKeepStr: "30"))
     }


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

# Problem Statement
- Problem statement : Deployment jenkins builds are restricted to single job at a time. 

# Design
-  For Bug, Describe the fix here. : Update deployment builds to accept 5 builds concurrently.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide