### PR TITLE
EOS-22429: Change in Alex workflow

### DIFF
--- a/.github/workflows/alex_reviewdog.yml
+++ b/.github/workflows/alex_reviewdog.yml
@@ -31,6 +31,7 @@ jobs:
   # Let's start the alex to scan
   alex:
     name: Alex report
+    # Label alex will trigger the workflow without creating new PR. Useful for debugging. 
     #if: ${{ github.event.label.name == 'alex' || github.event.action == 'synchronize' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Signed-off-by: Venkatesh K <venkatesh.k@seagate.com>

# Problem Statement
Alex is not getting triggered on raising a new PR

# Design
Changes are done so that Alex event will get triggered whenever the PR is opened (pull_request).
Kindly refer Alex documentation https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/584778705/Alex+Workflow.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide