### PR TITLE
EOS-25088: RPM validation job on CentOS-7.9.2009.

### DIFF
--- a/jenkins/automation/rpm-validation.groovy
+++ b/jenkins/automation/rpm-validation.groovy
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         node {
-            label 'automation-node-centos'
+            label "docker-${os_version}-node"
         }
     }
     
@@ -18,11 +18,6 @@ pipeline {
             description: 'Branch Name'
         )
         
-         choice(
-            name: 'os_version', 
-            choices: ['centos-7.8.2003', 'rhel-7.7.1908', 'centos-7.9.2009'],
-            description: 'OS Version'
-        )
 	}	
 	
 

--- a/scripts/release_support/rpm-validator.sh
+++ b/scripts/release_support/rpm-validator.sh
@@ -191,7 +191,7 @@ gpgkey=$BUILD_URL/RPM-GPG-KEY-Seagate
 priority=1
 EOF
 
-CENTOS_RELEASE="$(cat /etc/redhat-release | awk '{print $4}')"
+CENTOS_RELEASE="$(awk '{print $4}' /etc/redhat-release)"
 
 if [[ "$CENTOS_RELEASE" == "7.8.2003" ]]; then
     yum-config-manager --add-repo http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/centos/centos-7.8.2003-2.0.0-latest/


### PR DESCRIPTION
Signed-off-by: Nitish Singh <nitish.singh@seagate.com>

# Problem Statement
- RPM validation job on CentOS-7.9.2009.
- https://jts.seagate.com/browse/EOS-25088

# Design
-  Added option for CentOS 7.9.2009 rpm validation.
- Jenkins job-: http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/rpm_validation_CentOS_7.9.2009/

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
- Tested with build-: http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/rpm_validation_CentOS_7.9.2009/11/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide