### PR TITLE
EOS-24002 : Disabled minikube-functions.sh removal

### DIFF
--- a/solutions/kubernetes/minikube-functions.sh
+++ b/solutions/kubernetes/minikube-functions.sh
@@ -168,7 +168,6 @@ function cleanup_setup () {
         "${USER_HOME}/${USER}/.kube"
         "${USER_HOME}/${USER}/.minikube"
         "/etc/kubernetes/"
-        "/var/tmp/minikube-functions.sh"
     )
     if id -u "${USER}" >/dev/null 2>&1; then
         userdel -f "${USER}"


### PR DESCRIPTION
# Problem Statement
-  Minikube cluster setup failing

# Design
-  Bug - code is removing script after its placement in remote node. need to remove removal part of script.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
   http://eos-jenkins.colo.seagate.com/job/Cortx-Kubernetes/job/setup-minikube-cluster/27/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide