### PR TITLE
EOS-24388 Use dynamically provided branch name for Hare Build

### DIFF
--- a/jenkins/internal-ci/centos-7.9.2009/branch/hare.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/branch/hare.groovy
@@ -31,7 +31,7 @@ pipeline {
             steps {
                 script { build_stage = env.STAGE_NAME }
 				dir ('hare') {
-					checkout([$class: 'GitSCM', branches: [[name: 'main']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true], [$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: true, recursiveSubmodules: true, reference: '', shallow: true, trackingSubmodules: false]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', refspec: '+refs/heads/main:refs/remotes/origin/main', url: 'https://github.com/Seagate/cortx-hare']]])
+					checkout([$class: 'GitSCM', branches: [[name: "*/${branch}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true], [$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: true, recursiveSubmodules: true, reference: '', shallow: true, trackingSubmodules: false]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', refspec: '+refs/heads/main:refs/remotes/origin/main', url: 'https://github.com/Seagate/cortx-hare']]])
                 }
             }
         }


### PR DESCRIPTION
# Problem Statement
-  Branch name was hard coded as `main` hence for `stable` builds also `main` branch code was pulled.

# Design
-  For Bug, Describe the fix here.
    Removed hardcoding and used dynamically populated variable for branch name. 
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested with http://eos-jenkins.colo.seagate.com/job/Cortx-Stable/job/centos-7.9.2009/job/hare/36/console 
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide