### PR TITLE
EOS-24403 - Use services scripts dynamically for setup-cortx-cluster pipeline

### DIFF
--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -21,6 +21,8 @@ pipeline {
 
         string(name: 'CORTX_RE_BRANCH', defaultValue: 'kubernetes', description: 'Branch or GitHash for Cluster Setup scripts', trim: true)
         string(name: 'CORTX_RE_REPO', defaultValue: 'https://github.com/Seagate/cortx-re/', description: 'Repository for Cluster Setup scripts', trim: true)
+        string(name: 'CORTX_SCRIPTS_BRANCH', defaultValue: 'stable', description: 'Branch or GitHash for cortx-k8 repo', trim: true)
+        string(name: 'CORTX_SCRIPTS_REPO', defaultValue: 'Seagate/cortx-k8s', description: 'Repository for cortx-k8 repo', trim: true)
         text(defaultValue: '''hostname=<hostname>,user=<user>,pass=<password>''', description: 'VM details to be used for CORTX cluster setup. First node will be used as Master', name: 'hosts')
        
     }    
@@ -45,6 +47,8 @@ pipeline {
                         echo $hosts | tr ' ' '\n' > hosts
                         cat hosts
                         export GITHUB_TOKEN=${GITHUB_CRED}
+                        export CORTX_SCRIPTS_BRANCH=${CORTX_SCRIPTS_BRANCH}
+                        export CORTX_SCRIPTS_REPO=${CORTX_SCRIPTS_REPO}
                         ./cortx-deploy.sh --cortx-cluster
                     popd
                 '''


### PR DESCRIPTION
# Problem Statement
- POD's not getting created on the cluster. - Refer - http://eos-jenkins.colo.seagate.com/job/Cortx-Kubernetes/job/deploy-cortx-k8-cluster/21/ 

# Design
-  For Bug, Describe the fix here.  -  Modified Jenkinsfile to clone helm-chart repo from provided URL and branch name. 

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - http://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/setup-cortx-cluster/11/console 
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide