### PR TITLE
EOS-24404  - Increase Jenkins pipeline timeouts

### DIFF
--- a/jenkins/automation/kubernetes/deploy-cortx-k8-cluster.groovy
+++ b/jenkins/automation/kubernetes/deploy-cortx-k8-cluster.groovy
@@ -6,7 +6,7 @@ pipeline {
     }
     
     options {
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 240, unit: 'MINUTES')
         timestamps()
         buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '30'))
         ansiColor('xterm')

--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -6,7 +6,7 @@ pipeline {
     }
     
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 240, unit: 'MINUTES')
         timestamps()
         buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '30'))
         ansiColor('xterm')

--- a/jenkins/automation/kubernetes/setup-k8-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-k8-cluster.groovy
@@ -6,7 +6,7 @@ pipeline {
     }
     
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 240, unit: 'MINUTES')
         timestamps()
         buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '30'))
         ansiColor('xterm')

--- a/jenkins/automation/kubernetes/setup-third-party.groovy
+++ b/jenkins/automation/kubernetes/setup-third-party.groovy
@@ -6,7 +6,7 @@ pipeline {
     }
     
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 240, unit: 'MINUTES')
         timestamps()
         buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '30'))
         ansiColor('xterm')


### PR DESCRIPTION
# Problem Statement
- Jenkins pipelines are timing out for N+ node delpoyment. Hence increased Jenkins pipeline timeouts

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide