### PR TITLE
EOS-24404: Added support for v0.0.11

### DIFF
--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -78,9 +78,6 @@ function update_solution_config(){
         yq e -i '.solution.images.gluster = "docker.io/gluster/gluster-centos:latest"' solution.yaml
         yq e -i '.solution.images.rancher = "rancher/local-path-provisioner:v0.0.20"' solution.yaml
 
-        yq e -i '.solution.common.loadbal.control.externalips.ip1 = "192.168.1.2"' solution.yaml
-        yq e -i '.solution.common.loadbal.data.externalips.ip1 = "192.168.1.2"' solution.yaml
-	
         yq e -i '.solution.common.cortx_io_svc_ingress = false' solution.yaml
         drive=$SYSTEM_DRIVE_MOUNT yq e -i '.solution.common.storage_provisioner_path = env(drive)' solution.yaml
         yq e -i '.solution.common.storage.local = "/etc/cortx"' solution.yaml


### PR DESCRIPTION
# Problem Statement
- EOS-24404: Automated K8 orchestration and N node deployment pipeline.

# Design
-  Support for Cortx Services Release v0.0.11. Modified according to release v0.0.11 solution.yaml format.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Tested with Jenkins job-:
http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/test_cortx_setup/5/console

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide