### PR TITLE
EOS-24898 : Fixed s3 parity value.

### DIFF
--- a/jenkins/internal-ci/centos-7.9.2009/pr/mini_provisioning/s3server-mini_provisioning.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/pr/mini_provisioning/s3server-mini_provisioning.groovy
@@ -252,7 +252,7 @@ Recommended VM specification:
 
                             // Clone cortx-re repo
                             dir('cortx-re') {
-                                checkout([$class: 'GitSCM', branches: [[name: '*/fix-s3-parity']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', url: 'https://github.com/gauravchaudhari02/cortx-re']]])                
+                                checkout([$class: 'GitSCM', branches: [[name: '*/main']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', url: 'https://github.com/Seagate/cortx-re']]])                
                             }
                             
                             if ( "${params.HOST}" == "-" ) {


### PR DESCRIPTION
# Problem Statement
- S3 sanity tests are failing due to DI enabled parity config

# Design
-  For Bug - reverting parity to 1 from 0.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability 
   http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Mini-Provisioning/job/CentOS-7.9.2009/job/S3-Server/559/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide