### PR TITLE
EOS-24404: Added support for Release v0.0.13.

### DIFF
--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -96,35 +96,15 @@ function update_solution_config(){
         yq e -i '.solution.storage.cvg1.devices.data.d1.size = "5Gi"' solution.yaml
         yq e -i '.solution.storage.cvg1.devices.data.d2.device = "/dev/sde"' solution.yaml
         yq e -i '.solution.storage.cvg1.devices.data.d2.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d3.device = "/dev/sdf"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d3.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d4.device = "/dev/sdg"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d4.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d5.device = "/dev/sdh"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d5.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d6.device = "/dev/sdi"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d6.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d7.device = "/dev/sdj"' solution.yaml
-        yq e -i '.solution.storage.cvg1.devices.data.d7.size = "5Gi"' solution.yaml
        
         yq e -i '.solution.storage.cvg2.name = "cvg-02"' solution.yaml
         yq e -i '.solution.storage.cvg2.type = "ios"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.metadata.device = "/dev/sdk"' solution.yaml
+        yq e -i '.solution.storage.cvg2.devices.metadata.device = "/dev/sdf"' solution.yaml
         yq e -i '.solution.storage.cvg2.devices.metadata.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d1.device = "/dev/sdl"' solution.yaml
+        yq e -i '.solution.storage.cvg2.devices.data.d1.device = "/dev/sdg"' solution.yaml
         yq e -i '.solution.storage.cvg2.devices.data.d1.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d2.device = "/dev/sdm"' solution.yaml
+        yq e -i '.solution.storage.cvg2.devices.data.d2.device = "/dev/sdh"' solution.yaml
         yq e -i '.solution.storage.cvg2.devices.data.d2.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d3.device = "/dev/sdn"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d3.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d4.device = "/dev/sdo"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d4.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d5.device = "/dev/sdp"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d5.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d6.device = "/dev/sdq"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d6.size = "5Gi"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d7.device = "/dev/sdr"' solution.yaml
-        yq e -i '.solution.storage.cvg2.devices.data.d7.size = "5Gi"' solution.yaml
     popd
 }        
 


### PR DESCRIPTION
Signed-off-by: Nitish Singh <nitish.singh@seagate.com>

# Problem Statement
- EOS-24404: Automated K8 orchestration and N node deployment pipeline.

# Design
-  Support for Cortx Services Release v0.0.13. Modified according to release v0.0.13 solution.yaml format.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Single node-:
http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/test_cortx_setup/29/

- 3 node-:
http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/test_cortx_setup/28/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide