### PR TITLE
EOS-25657 - Job is failing because of missing (,)

### DIFF
--- a/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
@@ -176,7 +176,7 @@ pipeline {
 									      parameters: [
 									      	  string(name: 'HA_URL', value: "${HA_URL}"),
 									      	  string(name: 'HA_BRANCH', value: "${HA_BRANCH}"),
-										  string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}")	
+										  string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),	
 										  string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}")
 									      ]
 							} catch (err) {


### PR DESCRIPTION
Signed-off-by: Nikhil Patil <nikhil.patil@seagate.com>

# Problem Statement
- EOS-25657 - To fix custom CI pipeline for cortx-ha component (customized cortx-py-utils).

# Design
-  For Bug, While executing the Jenkins job we are going to pass the branch name and fetch it in code.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide