### PR TITLE
EOS-24407 - Allow POD's creation on master node in setup-kubernetes-cluster pipeline.

### DIFF
--- a/jenkins/automation/kubernetes/setup-k8-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-k8-cluster.groovy
@@ -21,7 +21,7 @@ pipeline {
         string(name: 'CORTX_RE_BRANCH', defaultValue: 'kubernetes', description: 'Branch or GitHash for Cluster Setup scripts', trim: true)
         string(name: 'CORTX_RE_REPO', defaultValue: 'https://github.com/Seagate/cortx-re/', description: 'Repository for Cluster Setup scripts', trim: true)
         text(defaultValue: '''hostname=<hostname>,user=<user>,pass=<password>''', description: 'VM details to be used for K8 cluster setup. First node will be used as Master', name: 'hosts')
-        booleanParam(name: 'PODS_ON_MASTER', defaultValue: false, description: 'Allow to schedule pods on master node')
+        booleanParam(name: 'PODS_ON_MASTER', defaultValue: false, description: 'Selecting this option will allow to schedule pods on master node.')
     }    
 
     stages {


### PR DESCRIPTION
# Problem Statement
- Allow POD's creation on master node in setup-kubernetes-cluster pipeline.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested using - http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/setup-kubernetes-cluster/5
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide