### PR TITLE
EOS-26086: Kubernetes deployment fails on Manually created VMs using ISO.

### DIFF
--- a/solutions/kubernetes/cluster-functions.sh
+++ b/solutions/kubernetes/cluster-functions.sh
@@ -164,7 +164,10 @@ function install_prerequisites(){
         # stop and disable firewalld
         (systemctl stop firewalld && systemctl disable firewalld && sudo systemctl mask --now firewalld) || throw $Exception
         # install python packages
-        (yum install python3-pip && pip3 install jq yq) || throw $Exception
+        (yum install python3-pip -y && pip3 install jq yq) || throw $Exception
+
+        # install yum-utils and wget
+        yum install yum-utils wget -y || throw $Exception
 
         # set yum repositories for k8 and docker-ce
         rm -rf /etc/yum.repos.d/download.docker.com_linux_centos_7_x86_64_stable_.repo /etc/yum.repos.d/packages.cloud.google.com_yum_repos_kubernetes-el7-x86_64.repo


### PR DESCRIPTION
Added yum-utils and wget install options for VM's they are not present by default.

Signed-off-by: Nitish Singh <nitish.singh@seagate.com>

# Problem Statement
- EOS-26086: Kubernetes deployment fails on Manually created VMs using ISO.

# Design
-  Added yum-utils and wget installation.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Jenkins job:
http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/test_k8s_setup/16/console

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide