### PR TITLE
EOS-26113 : Update timeout for s3 pre-merge job

### DIFF
--- a/jenkins/internal-ci/centos-7.9.2009/pr/component_test/s3server-premerge.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/pr/component_test/s3server-premerge.groovy
@@ -8,7 +8,7 @@ pipeline {
 
 	options {
 		timestamps() 
-	    timeout(time: 480, unit: 'MINUTES')
+	    timeout(time: 600, unit: 'MINUTES')
         buildDiscarder(logRotator(daysToKeepStr: '7', numToKeepStr: '30'))
 	}
 


### PR DESCRIPTION
# Problem Statement
- S3 pre-merge job failing due to less timeout.

# Design
-  Increase timeout from 6 hrs to 10 hrs.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
   http://eos-jenkins.colo.seagate.com/job/S3server/job/S3Server-PreMerge-Test/565/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide