### PR TITLE
EOS-25958 : Kubernetes CICD with 3-Node in nightly basis

### DIFF
--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -9,6 +9,7 @@ pipeline {
         timeout(time: 600, unit: 'MINUTES')
         timestamps()
         buildDiscarder(logRotator(daysToKeepStr: '20', numToKeepStr: '20'))
+        disableConcurrentBuilds()
     }
 
     environment {


### PR DESCRIPTION
# Problem Statement
- EOS-25958 Kubernetes CICD jenkins job with 3-Node in nightly basis

# Design
For Kubernetes CI/CD with nightly basis I have follow below steps.
1. I have run Kubernetes cluster setup job manually on newly created nodes.
2. Run cortx setup jobs which will start pods on above nodes.
3. Run same jobs 2-3 times for testing purpose on same nodes.
4. Created nightly job and written one groovy script which is creating cortx all build and then creating docker images by that 
build, then we setup kube cluster and deployment that docker image on same cluster.
5. I have testing this nightly job manually 2-3 times and by auto trigger 1 time.

Please find below Jenkins job and groovy script link. This one is testing job once PR is merge then I will move same job on Cortx-kubernetes folder.

http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/Nightly-Build-and-Deploy/

https://github.com/AbhijitPatil1992/cortx-re/blob/kubernetes/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide