### PR TITLE
EOS-22192 Fix issue with RELEASE.INFO

### DIFF
--- a/docker/cortx-deploy/generate-release-info.sh
+++ b/docker/cortx-deploy/generate-release-info.sh
@@ -29,9 +29,9 @@ NAME: "CORTX"
 OS: $(cat /etc/redhat-release | sed -e 's/ $//g' -e 's/^/\"/g' -e 's/$/\"/g')
 DATETIME: $(date +"%d-%b-%Y %H:%M %Z" | sed -e 's/^/\"/g' -e 's/$/\"/g')
 COMPONENTS:
-$(for component in $(sed 's/#.*//g' /opt/seagate/cortx/cortx-componenet-rpms.txt); do echo "    - \"$(rpm -qa $component).rpm\"" ; done)
+$(for component in $(sed 's/#.*//g' /opt/seagate/cortx/cortx-componenet-rpms.txt); do echo "    - \"$(rpm -q $component).rpm\"" ; done)
 THIRD_PARTY_RPM_PACKAGES:
-$(for component in $(sed 's/#.*//g' /opt/seagate/cortx/third-party-rpms.txt); do echo "    - \"$(rpm -qa $component).rpm\"" ; done)
+$(for component in $(sed 's/#.*//g' /opt/seagate/cortx/third-party-rpms.txt); do echo "    - \"$(rpm -q $component).rpm\"" ; done)
 THIRD_PARTY_PYTHON_PACKAGES:
 $(pip3 freeze | sed 's/^/    - /g')
 EOF


### PR DESCRIPTION
# Problem Statement
- RELEASE.INFO is not showing proper output. It's showing output as below,

```
[root@ssc-vm-rhev4-0707 cortx-deploy]# docker run --rm ghcr.io/seagate/cortx-all:2.0.0-latest-custom-ci cat /opt/seagate/cortx/RELEASE.INFO
---
NAME: "CORTX"
OS: "CentOS Linux release 7.9.2009 (Core)"
DATETIME: "23-Nov-2021 14:59 UTC"
COMPONENTS:
    - "cortx-py-utils-2.0.0-1080_0457ceb.noarch.rpm"
    - "cortx-hare-2.0.0-444_gitc0eb48a.el7.x86_64.rpm"
    - "cortx-motr-2.0.0-444_gitad1f2b09_3.10.0_1160.el7.x86_64.rpm"
    - "cortx-s3server-2.0.0-444_git3581601f_el7.x86_64.rpm"
    - "cortx-csm_agent-2.0.0-444_b3c80e82.x86_64.rpm"
    - "cortx-provisioner-2.0.0-444_ac9bb329.noarch.rpm"
    - "cortx-ha-2.0.0-444_282f4a9.x86_64.rpm"
THIRD_PARTY_RPM_PACKAGES:
    - "crontabs-1.11-6.20121102git.el7.noarch.rpm"
    - "haproxy22-2.2.9-3.el7.ius.x86_64.rpm"
    - "java-1.8.0-openjdk-headless-1.8.0.262.b10-1.el7.x86_64.rpm"
    - "jq-1.6-2.el7.x86_64.rpm"
    - "kafka-2.13_2.7.0-el7.x86_64.rpm"
    - "logrotate-3.8.6-19.el7.x86_64.rpm"
    - "python3-3.6.8-17.el7.x86_64.rpm"
    - "python36-dbus-1.2.4-4.el7.x86_64.rpm"
    - "python36-m2crypto-0.35.2-5.el7.x86_64.rpm"
    - "python36-psutil-5.6.7-1.el7.x86_64.rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - ".rpm"
    - "sshpass-1.06-2.el7.x86_64.rpm"
    - "sudo-1.8.23-10.el7.x86_64.rpm"
    - "symas-openldap-clients-2.4.58-1.el7.x86_64.rpm"
    - "which-2.20-7.el7.x86_64.rpm"
```

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design  - Fixed `rpm` command used to query package. 

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability. Tested with http://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/cortx-all-docker-image/197/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide