### PR TITLE
EOS-25958 : Added Post Action for Email notification in K8S deployment job

### DIFF
--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -172,6 +172,14 @@ pipeline {
 					env.deployment_result = "SUCCESS"
 					env.sanity_result = "SUCCESS"
 					currentBuild.result = "SUCCESS"
+				} else if ( "${env.cortxCluster_status}" == "FAILURE" || "${env.cortxCluster_status}" == "UNSTABLE" || "${env.cortxCluster_status}" == "null" ) {
+					manager.buildFailure()
+					MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=failed, SanityTest=skipped"
+					ICON = "error.gif"
+					STATUS = "FAILURE"
+					env.sanity_result = "FAILURE"
+					env.deployment_result = "FAILURE"
+					currentBuild.result = "FAILURE"
 				} else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" ) {
 					manager.buildFailure()
 					MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=Passed, SanityTest=failed"
@@ -187,14 +195,6 @@ pipeline {
 					env.deployment_result = "SUCCESS"
 					env.sanity_result = "UNSTABLE"
 					currentBuild.result = "UNSTABLE"
-				} else if ( "${env.cortxCluster_status}" == "FAILURE" || "${env.cortxCluster_status}" == "UNSTABLE" || "${env.cortxCluster_status}" == "null" ) {
-					manager.buildFailure()
-					MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=failed, SanityTest=skipped"
-					ICON = "error.gif"
-					STATUS = "FAILURE"
-					env.sanity_result = "FAILURE"
-					env.deployment_result = "FAILURE"
-					currentBuild.result = "FAILURE"
 				} else {
 					MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=unstable, SanityTest=unstable"
 					ICON = "unstable.gif"


### PR DESCRIPTION
# Problem Statement
- EOS-25958: Added Post Action for Email notification in K8S deployment job

# Design
- We have already created nightly k8s cluster deployment job.
- Now added only email notification in same job.
- We have tested same thing by below test job.
     http://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/Nightly%20Pipelines/job/Nightly-K8s-Build-and-Deploy
     https://github.com/AbhijitPatil1992/cortx-re/blob/kubernetes/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
- Please find below screenshot for email notification format
![image](https://user-images.githubusercontent.com/91177718/143834871-fa926a4d-9148-44af-9316-4c96604a4ff2.png)


# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide