### PR TITLE
EOS-25328 Changes for S3 Premerge Motr Branch variable

### DIFF
--- a/jenkins/internal-ci/centos-7.9.2009/pr/component_test/s3server-premerge.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/pr/component_test/s3server-premerge.groovy
@@ -31,7 +31,7 @@ pipeline {
         S3_PR_REFSEPEC = "${ghprbPullId != null ? S3_GPR_REFSEPEC : S3_BRANCH_REFSEPEC}"
         BUILD_TRIGGER_BY = "${currentBuild.getBuildCauses()[0].shortDescription}"
 	MOTR_BRANCH = "main"
-	// MOTR_BRANCH variable used for when we trigger build by timer then motr branch will checkout from main branch
+	// MOTR_BRANCH variable used only if build is triggered by timer.
     }
  	
 	stages {	


### PR DESCRIPTION
# Problem Statement
- EOS-25328 Changes for S3 Premerge Motr Branch variable

# Design
-  I have moved motr branch parameter as a environment variable.
-  Please find below test job and groovy script location.
   http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/Test_s3_premerge_job/220/console
   https://github.com/Seagate/cortx-re/blob/main/jenkins/internal-ci/centos-7.9.2009/pr/component_test/s3server-premerge.groovy

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide