### PR TITLE
EOS-25936 - Fix Nightly CORTX-ALL Docker Image failure.

### DIFF
--- a/jenkins/automation/kubernetes/nightly-cortx-image.groovy
+++ b/jenkins/automation/kubernetes/nightly-cortx-image.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     parameters: [
                                         string(name: 'CORTX_RE_URL', value: "https://github.com/Seagate/cortx-re"),
                                         string(name: 'CORTX_RE_BRANCH', value: "kubernetes"),
-                                        string(name: 'BUILD', value: "${release_tag}"),
+                                        string(name: 'BUILD', value: "kubernetes-build-${env.custom_ci_build_id}"),
                                         string(name: 'GITHUB_PUSH', value: "yes"),
                                         string(name: 'TAG_LATEST', value: "yes"),
                                         string(name: 'DOCKER_REGISTRY', value: "ghcr.io"),


### PR DESCRIPTION
# Problem Statement
- Nightly CORTX-ALL Docker Image was failing due to incorrect build url passed to image creation job. 


# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability. Tested as per http://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/Nightly%20CORTX-ALL%20Docker%20Image/200/ 
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide