### PR TITLE
EOS-26145 Cleanup images from node after push. 

### DIFF
--- a/jenkins/automation/kubernetes/cortx-all-image.groovy
+++ b/jenkins/automation/kubernetes/cortx-all-image.groovy
@@ -56,7 +56,7 @@ pipeline {
                 sh encoding: 'utf-8', label: 'Validate Docker pre-requisite', script: """
                    systemctl status docker
                    /usr/local/bin/docker-compose --version
-                   docker rmi --force \$(docker images cortx-all -q)
+                   if docker images | grep cortx-all -q; then docker rmi --force \$(docker images cortx-all -q); fi
                    echo 'y' | docker image prune
                 """
             }


### PR DESCRIPTION
# Problem Statement
-  Old Docker images are consuming disk space on the image generation node causing image creation job failure. 
```
12:25:21    installing package consul-1.9.1-1.x86_64 needs 253MB on the / filesystem
12:25:21    installing package cortx-hare-2.0.0-1325_gite9d1068.el7.x86_64 needs 346MB on the / filesystem
12:25:21    installing package cortx-s3server-2.0.0-1325_gitb0169f74_el7.x86_64 needs 381MB on the / filesystem
12:25:21    installing package cortx-csm_agent-2.0.0-1325_ddeaf53b.x86_64 needs 384MB on the / filesystem
12:25:21    installing package cortx-provisioner-2.0.0-1325_594f8361.noarch needs 384MB on the / filesystem
12:25:21    installing package cortx-ha-2.0.0-1325_282f4a9.x86_64 needs 388MB on the / filesystem
12:25:21  
12:25:21  Error Summary
12:25:21  -------------
12:25:21  Disk Requirements:
12:25:21    At least 388MB more space needed on the / filesystem.
```

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability. Tested using - http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/sv-cortx-all-image/44/console
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide