### PR TITLE
EOS-26747 - Added two parameters SNS_CONFIG and DIX_CONFIG in Nightly Job

### DIFF
--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -222,8 +222,7 @@ pipeline {
 				} else if ( params.EMAIL_RECIPIENTS == "DEVOPS" ) {
 					mailRecipients = "CORTX.DevOps.RE@seagate.com"
 				} else if ( params.EMAIL_RECIPIENTS == "DEBUG" ) {
-//					mailRecipients = "akhil.bhansali@seagate.com, amit.kapil@seagate.com, amol.j.kongre@seagate.com, deepak.choudhary@seagate.com, jaikumar.gidwani@seagate.com, mandar.joshi@seagate.com, neerav.choudhari@seagate.com, pranay.kumar@seagate.com, swarajya.pendharkar@seagate.com, taizun.a.kachwala@seagate.com, trupti.patil@seagate.com, ujjwal.lanjewar@seagate.com, shailesh.vaidya@seagate.com, abhijit.patil@seagate.com, sonal.kalbende@seagate.com, gaurav.chaudhari@seagate.com, don.r.bloyer@seagate.com, kalpesh.chhajed@seagate.com"
-					 mailRecipients = "shailesh.vaidya@seagate.com, abhijit.patil@seagate.com"
+					mailRecipients = "akhil.bhansali@seagate.com, amit.kapil@seagate.com, amol.j.kongre@seagate.com, deepak.choudhary@seagate.com, jaikumar.gidwani@seagate.com, mandar.joshi@seagate.com, neerav.choudhari@seagate.com, pranay.kumar@seagate.com, swarajya.pendharkar@seagate.com, taizun.a.kachwala@seagate.com, trupti.patil@seagate.com, ujjwal.lanjewar@seagate.com, shailesh.vaidya@seagate.com, abhijit.patil@seagate.com, sonal.kalbende@seagate.com, gaurav.chaudhari@seagate.com, don.r.bloyer@seagate.com, kalpesh.chhajed@seagate.com"
 				}
 				catchError(stageResult: 'FAILURE') {
 					archiveArtifacts allowEmptyArchive: true, artifacts: 'log/*report.xml, log/*report.html, support_bundle/*.tar, crash_files/*.gz', followSymlinks: false


### PR DESCRIPTION
Signed-off-by: AbhijitPatil1992 <abhijit.patil@seagate.com>

# Problem Statement
- Added two parameters SNS_CONFIG and DIX_CONFIG in Nightly Job

# Design
-  We added SNS_CONFIG and DIX_CONFIG parameters in nightly job passing this with setup cortx cluster job.
-  Please find below jenkins job and groovy script.
      http://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/Nightly%20Pipelines/job/Nightly-K8s-Build-and-Deploy/42/console
      https://github.com/Seagate/cortx-re/blob/kubernetes/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide