### PR TITLE
Enable crash dump settings on VMs for s3 specific jobs

### DIFF
--- a/jenkins/automation/s3server/s3-compatibility-test-ceph.groovy
+++ b/jenkins/automation/s3server/s3-compatibility-test-ceph.groovy
@@ -3,7 +3,7 @@ pipeline {
     agent {
 		node {
             // Agent created with 4GB ram/16GB memory in EOS_SVC_RE1 account 
-			label "s3-compatibility-test-ceph-rhev-7.9-temp"
+			label "s3-compatibility-test-ceph-rhev-7.9"
 
             // Use custom workspace for easy troublshooting
             customWorkspace "/root/compatability-test/${INTEGRATION_TYPE}"

--- a/jenkins/automation/s3server/s3-compatibility-test-splunk.groovy
+++ b/jenkins/automation/s3server/s3-compatibility-test-splunk.groovy
@@ -66,7 +66,7 @@ pipeline {
 
                     dir('cortx-s3server') {
                         
-                        sh label: 'Enable crash dump', script: """
+                        sh label: 'Enable crash dump', script: '''
                             var1=$(sysctl kernel.printk|awk '{print $3}')
                             var2=$(sysctl kernel.core_pattern|awk '{print $3}'|grep "/var/crash/core.%u.%e.%p"|wc -l)
 
@@ -80,7 +80,7 @@ pipeline {
                             else
                                 echo "Crash dump is already enabled"
                             fi
-                        """
+                        '''
                         // previous build, support bundle cleanup
                         sh label: 'cleanup', script: """
                             rm -rf /root/.seagate_src_cache/

--- a/jenkins/internal-ci/centos-7.9.2009/pr/component_test/s3server-premerge.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/pr/component_test/s3server-premerge.groovy
@@ -69,7 +69,7 @@ pipeline {
                     script { build_stage = env.STAGE_NAME }
                     script {
 
-                        sh label: 'Enable crash dump', script: """
+                        sh label: 'Enable crash dump', script: '''
                             var1=$(sysctl kernel.printk|awk '{print $3}')
                             var2=$(sysctl kernel.core_pattern|awk '{print $3}'|grep "/var/crash/core.%u.%e.%p"|wc -l)
 
@@ -83,7 +83,7 @@ pipeline {
                             else
                                 echo "Crash dump is already enabled"
                             fi
-                        """
+                        '''
 
                         sh label: 'Script', script: """
                             git remote -v 

--- a/jenkins/internal-ci/centos-7.9.2009/pr/mini_provisioning/s3server-mini_provisioning.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/pr/mini_provisioning/s3server-mini_provisioning.groovy
@@ -103,7 +103,7 @@ Recommended VM specification:
 
                     checkout([$class: 'GitSCM', branches: [[name: "${S3_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'AuthorInChangelog'], [$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: true, recursiveSubmodules: true, reference: '', trackingSubmodules: false], [$class: 'CloneOption', depth: 1, honorRefspec: true, noTags: true, reference: '', shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', url: "${S3_URL}",  name: 'origin', refspec: "${S3_PR_REFSEPEC}"]]])
 
-                    sh label: 'Enable crash dump', script: """
+                    sh label: 'Enable crash dump', script: '''
                         var1=$(sysctl kernel.printk|awk '{print $3}')
                         var2=$(sysctl kernel.core_pattern|awk '{print $3}'|grep "/var/crash/core.%u.%e.%p"|wc -l)
 
@@ -117,7 +117,7 @@ Recommended VM specification:
                         else
                             echo "Crash dump is already enabled"
                         fi
-                    """
+                    '''
 
                     sh label: 'prepare build env', script: """
                         yum-config-manager --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/components/github/$BRANCH/$OS_VERSION/dev/motr/current_build/


### PR DESCRIPTION
# Problem Statement
- Enable crash dump settings on VMs for s3 specific jobs

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide