### PR TITLE
Single node sns-dix export fix.

### DIFF
--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -79,7 +79,7 @@ function setup_cluster {
     if [ "$(wc -l < $HOST_FILE)" == "1" ]; then
        echo "---------------------------------------[ Single node deployment ]----------------------------------"
        echo "NODE:" $MASTER_NODE
-       ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" "export SOLUTION_CONFIG_TYPE=$SOLUTION_CONFIG_TYPE && export CORTX_IMAGE=$CORTX_IMAGE && export CORTX_SCRIPTS_REPO=$CORTX_SCRIPTS_REPO && export CORTX_SCRIPTS_BRANCH=$CORTX_SCRIPTS_BRANCH && /var/tmp/cortx-deploy-functions.sh --setup-master"
+       ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" "export SOLUTION_CONFIG_TYPE=$SOLUTION_CONFIG_TYPE && export CORTX_IMAGE=$CORTX_IMAGE && export CORTX_SCRIPTS_REPO=$CORTX_SCRIPTS_REPO && export CORTX_SCRIPTS_BRANCH=$CORTX_SCRIPTS_BRANCH && export SNS_CONFIG=$SNS_CONFIG && export DIX_CONFIG=$DIX_CONFIG && /var/tmp/cortx-deploy-functions.sh --setup-master"
     else
        WORKER_NODES=$(cat "$HOST_FILE" | grep -v "$MASTER_NODE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
     fi


### PR DESCRIPTION
Signed-off-by: Nitish Singh <nitish.singh@seagate.com>

# Problem Statement
- Single node sns-dix env not found

# Design
-  Exported the sns-dix to single node setup-master.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_deploy_k8s_cortx_cluster/38/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide