### PR TITLE
EOS-26146: Changes for SNS DIX config removed exit1

### DIFF
--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -40,8 +40,8 @@ function check_params {
     if [ -z "$CORTX_SCRIPTS_BRANCH" ]; then echo "CORTX_SCRIPTS_BRANCH not provided.Exiting..."; exit 1; fi
     if [ -z "$CORTX_IMAGE" ]; then echo "CORTX_IMAGE not provided.Exiting..."; exit 1; fi
     if [ -z "$SOLUTION_CONFIG_TYPE" ]; then echo "SOLUTION_CONFIG_TYPE not provided.Exiting..."; exit 1; fi
-    if [ -z "$SNS_CONFIG" ]; then SNS_CONFIG="1+0+0"; exit 1; fi
-    if [ -z "$DIX_CONFIG" ]; then DIX_CONFIG="1+0+0"; exit 1; fi
+    if [ -z "$SNS_CONFIG" ]; then SNS_CONFIG="1+0+0"; fi
+    if [ -z "$DIX_CONFIG" ]; then DIX_CONFIG="1+0+0"; fi
 }
 
 function pdsh_worker_exec {


### PR DESCRIPTION
Signed-off-by: AbhijitPatil1992 <abhijit.patil@seagate.com>

# Problem Statement
- EOS-26146: Changes for SNS DIX config removed exit1

# Design
-  Removed exit 1 from cortx deployment script for SNS and DIX CONFIG.
     Here is the jenkins job where I have tested this change.
     http://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/setup-cortx-cluster-solution-input/168/console

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide