### PR TITLE
EOS-26148: Single node setup_master twice implementation fix.

### DIFF
--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -84,19 +84,19 @@ function setup_cluster {
        WORKER_NODES=$(cat "$HOST_FILE" | grep -v "$MASTER_NODE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
     fi
 
-    # Setup all worker nodes in parallel in case of multinode cluster.
+    # Setup master node and all worker nodes in parallel in case of multinode cluster.
     if [ "$(wc -l < $HOST_FILE)" -ne "1" ]; then
        echo "MASTER NODE:" $MASTER_NODE
        echo "WORKER NODE:" $WORKER_NODES
        # pdsh hosts to run parallel implementations.
        echo $WORKER_NODES > /var/tmp/pdsh-hosts
        pdsh_worker_exec /var/tmp/pdsh-hosts
-    fi
 
-    for master_node in $MASTER_NODE
-	    do
-    	ssh -o 'StrictHostKeyChecking=no' "$master_node" "export SOLUTION_CONFIG_TYPE=$SOLUTION_CONFIG_TYPE && export CORTX_IMAGE=$CORTX_IMAGE && export CORTX_SCRIPTS_REPO=$CORTX_SCRIPTS_REPO && export CORTX_SCRIPTS_BRANCH=$CORTX_SCRIPTS_BRANCH && export SNS_CONFIG=$SNS_CONFIG && export DIX_CONFIG=$DIX_CONFIG && /var/tmp/cortx-deploy-functions.sh --setup-master"
-        done
+       for master_node in $MASTER_NODE
+           do
+               ssh -o 'StrictHostKeyChecking=no' "$master_node" "export SOLUTION_CONFIG_TYPE=$SOLUTION_CONFIG_TYPE && export CORTX_IMAGE=$CORTX_IMAGE && export CORTX_SCRIPTS_REPO=$CORTX_SCRIPTS_REPO && export CORTX_SCRIPTS_BRANCH=$CORTX_SCRIPTS_BRANCH && export SNS_CONFIG=$SNS_CONFIG && export DIX_CONFIG=$DIX_CONFIG && /var/tmp/cortx-deploy-functions.sh --setup-master"
+           done
+    fi
 
     for master_node in $MASTER_NODE
         do

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -86,6 +86,8 @@ function setup_cluster {
 
     # Setup master node and all worker nodes in parallel in case of multinode cluster.
     if [ "$(wc -l < $HOST_FILE)" -ne "1" ]; then
+       NODES=$(wc -l < $HOST_FILE)
+       echo "---------------------------------------[ $NODES node deployment ]----------------------------------"
        echo "MASTER NODE:" $MASTER_NODE
        echo "WORKER NODE:" $WORKER_NODES
        # pdsh hosts to run parallel implementations.

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -87,6 +87,8 @@ function setup_cluster {
     # Setup master node and all worker nodes in parallel in case of multinode cluster.
     if [ "$(wc -l < $HOST_FILE)" -ne "1" ]; then
        NODES=$(wc -l < $HOST_FILE)
+       TAINTED_NODES=$(kubectl get nodes -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints[?(@.effect=='NoSchedule')].effect}{\"\n\"}{end}" | grep  NoSchedule | wc -l)
+       NODES=$((NODES-TAINTED_NODES))
        echo "---------------------------------------[ $NODES node deployment ]----------------------------------"
        echo "MASTER NODE:" $MASTER_NODE
        echo "WORKER NODE:" $WORKER_NODES

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -87,8 +87,12 @@ function setup_cluster {
     # Setup master node and all worker nodes in parallel in case of multinode cluster.
     if [ "$(wc -l < $HOST_FILE)" -ne "1" ]; then
        NODES=$(wc -l < $HOST_FILE)
-       TAINTED_NODES=$(ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" "kubectl get nodes -o jsonpath=\"{range .items[*]}{.metadata.name} {.spec.taints[?(@.effect=='NoSchedule')].effect}{\"\n\"}{end}\" | grep  NoSchedule | wc -l)"
-       NODES=$((NODES-TAINTED_NODES))
+       TAINTED_NODES=$(
+           ssh -o 'StrictHostKeyChecking=no' ssc-vm-rhev4-1222.colo.seagate.com bash << EOF
+           kubectl get nodes -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints[?(@.effect=='NoSchedule')].effect}{\"\n\"}{end}" | grep  NoSchedule | wc -l
+           EOF
+           )
+       NODES="$((NODES-TAINTED_NODES))"
        echo "---------------------------------------[ $NODES node deployment ]----------------------------------"
        echo "MASTER NODE:" $MASTER_NODE
        echo "WORKER NODE:" $WORKER_NODES

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -87,7 +87,7 @@ function setup_cluster {
     # Setup master node and all worker nodes in parallel in case of multinode cluster.
     if [ "$(wc -l < $HOST_FILE)" -ne "1" ]; then
        NODES=$(wc -l < $HOST_FILE)
-       TAINTED_NODES=$(kubectl get nodes -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints[?(@.effect=='NoSchedule')].effect}{\"\n\"}{end}" | grep  NoSchedule | wc -l)
+       TAINTED_NODES=$(ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" "kubectl get nodes -o jsonpath=\"{range .items[*]}{.metadata.name} {.spec.taints[?(@.effect=='NoSchedule')].effect}{\"\n\"}{end}\" | grep  NoSchedule | wc -l)"
        NODES=$((NODES-TAINTED_NODES))
        echo "---------------------------------------[ $NODES node deployment ]----------------------------------"
        echo "MASTER NODE:" $MASTER_NODE

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -87,11 +87,10 @@ function setup_cluster {
     # Setup master node and all worker nodes in parallel in case of multinode cluster.
     if [ "$(wc -l < $HOST_FILE)" -ne "1" ]; then
        NODES=$(wc -l < $HOST_FILE)
-       TAINTED_NODES=$(
-           ssh -o 'StrictHostKeyChecking=no' ssc-vm-rhev4-1222.colo.seagate.com bash << EOF
-           kubectl get nodes -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints[?(@.effect=='NoSchedule')].effect}{\"\n\"}{end}" | grep  NoSchedule | wc -l
-           EOF
-           )
+       TAINTED_NODES=$(ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" bash << EOF
+kubectl get nodes -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints[?(@.effect=='NoSchedule')].effect}{\"\n\"}{end}" | grep  NoSchedule | wc -l
+EOF
+)
        NODES="$((NODES-TAINTED_NODES))"
        echo "---------------------------------------[ $NODES node deployment ]----------------------------------"
        echo "MASTER NODE:" $MASTER_NODE


### PR DESCRIPTION
# Problem Statement
- On single node deployment, the setup_master function was executing two times.

# Design
-  Implemented fix for twice setup_master function execution for single node deployment.
-  Implemented total node count echo flag for multi-node deployment.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Single node-:
http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_cortx_setup/103/parameters/
- 3 node with control node untainted-:
http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_cortx_setup/102/parameters/
- 1 + 3 node with control node tainted-:
http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_cortx_setup/108/parameters/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide