### PR TITLE
EOS-27033 Remove obsolete Provisioner RPM's from kubernetes build generation

### DIFF
--- a/jenkins/automation/kubernetes/k8-custom-ci.groovy
+++ b/jenkins/automation/kubernetes/k8-custom-ci.groovy
@@ -410,14 +410,7 @@ pipeline {
             steps {
 
                 sh label: 'Additional Files', script:'''
-                #Add cortx-prep.sh
-                mkdir -p $integration_dir/$release_tag/iso
-                cortx_prvsnr_preq=$(ls "$integration_dir/$release_tag/cortx_iso" | grep "python36-cortx-prvsnr" | cut -d- -f5 | cut -d_ -f2 | cut -d. -f1 | sed s/"git"//)                 
-                wget -O $integration_dir/$release_tag/iso/install-$version-$BUILD_NUMBER.sh https://raw.githubusercontent.com/Seagate/cortx-prvsnr/$cortx_prvsnr_preq/srv/components/provisioner/scripts/install.sh
-
-                #Add custom-os ISO
-                ln -s $cortx_os_iso $integration_dir/$release_tag/iso/$(basename $cortx_os_iso)
-
+               
                 #Remove Build details from THIRD_PARTY_RELEASE.INFO
                 sed -i '/BUILD/d' $integration_dir/$release_tag/3rd_party/THIRD_PARTY_RELEASE.INFO
                 '''

--- a/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
@@ -400,11 +400,7 @@ pipeline {
             steps {
 
                 sh label: 'Additional Files', script:'''
-                #Add cortx-prep.sh
-                mkdir -p $integration_dir/$release_tag/iso
-                cortx_prvsnr_preq=$(ls "$integration_dir/$release_tag/cortx_iso" | grep "python36-cortx-prvsnr" | cut -d- -f5 | cut -d_ -f2 | cut -d. -f1 | sed s/"git"//)
-                wget -O $integration_dir/$release_tag/iso/install-$version-$BUILD_NUMBER.sh https://raw.githubusercontent.com/Seagate/cortx-prvsnr/$cortx_prvsnr_preq/srv/components/provisioner/scripts/install.sh
-
+                
                 #Add custom-os ISO
                 ln -s $cortx_os_iso $integration_dir/$release_tag/iso/$(basename $cortx_os_iso)
 

--- a/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
@@ -396,14 +396,10 @@ pipeline {
             }
         }
 
-        stage ('Additional Files') {
+        stage ('Cleanup') {
             steps {
 
-                sh label: 'Additional Files', script:'''
-                
-                #Add custom-os ISO
-                ln -s $cortx_os_iso $integration_dir/$release_tag/iso/$(basename $cortx_os_iso)
-
+                sh label: 'Cleanup', script:'''
                 #Remove Build details from THIRD_PARTY_RELEASE.INFO
                 sed -i '/BUILD/d' $integration_dir/$release_tag/3rd_party/THIRD_PARTY_RELEASE.INFO
                 '''

--- a/jenkins/custom-ci/centos-7.9.2009/provisioner.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/provisioner.groovy
@@ -55,7 +55,6 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''
                     mkdir -p $build_upload_dir
-                    cp /root/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir
                     shopt -s extglob
                     if ls ./dist/*.rpm; then
                         cp ./dist/!(*.src.rpm|*.tar.gz) $build_upload_dir

--- a/jenkins/custom-ci/centos-7.9.2009/provisioner.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/provisioner.groovy
@@ -1,16 +1,16 @@
 #!/usr/bin/env groovy
-pipeline { 
+pipeline {
     agent {
         node {
             label 'docker-centos-7.9.2009-node'
         }
     }
-    
-    parameters {  
+
+    parameters {
         string(name: 'PRVSNR_URL', defaultValue: 'https://github.com/Seagate/cortx-prvsnr', description: 'Repository URL for Provisioner.')
         string(name: 'PRVSNR_BRANCH', defaultValue: 'stable', description: 'Branch for Provisioner.')
         string(name: 'CUSTOM_CI_BUILD_ID', defaultValue: '0', description: 'Custom CI Build Number')
-    }    
+    }
 
     environment {
         component = "provisioner"
@@ -27,7 +27,7 @@ pipeline {
         ansiColor('xterm')
         buildDiscarder(logRotator(daysToKeepStr: '5', numToKeepStr: '10'))
     }
-    
+
     stages {
         stage('Checkout') {
             steps {
@@ -39,40 +39,13 @@ pipeline {
         stage('Build') {
             steps {
                 script { build_stage = env.STAGE_NAME }
-                sh encoding: 'utf-8', label: 'Provisioner RPMS', returnStdout: true, script: """
-                    rm -rf /etc/yum.repos.d/CentOS-*
-                    sh ./devops/rpms/buildrpm.sh -g \$(git rev-parse --short HEAD) -e 2.0.0 -b ${CUSTOM_CI_BUILD_ID}
-                """
-                sh encoding: 'utf-8', label: 'Provisioner CLI RPMS', returnStdout: true, script: """
-                    sh ./cli/buildrpm.sh -g \$(git rev-parse --short HEAD) -e 2.0.0 -b ${CUSTOM_CI_BUILD_ID}
-                """
-
-                sh encoding: 'UTF-8', label: 'cortx-setup', script: """
-                if [ -f "./devops/rpms/node_cli/node_cli_buildrpm.sh" ]; then
-                    sh ./devops/rpms/node_cli/node_cli_buildrpm.sh -g \$(git rev-parse --short HEAD) -e 2.0.0 -b ${CUSTOM_CI_BUILD_ID}
-                else
-                    echo "node_cli package creation is not implemented"
-                fi
-                """
-                
-                sh encoding: 'UTF-8', label: 'api', script: '''
-                    bash ./devops/rpms/api/build_python_api.sh -vv --out-dir /root/rpmbuild/RPMS/x86_64/ --pkg-ver ${CUSTOM_CI_BUILD_ID}_git$(git rev-parse --short HEAD)
-                '''
-
-                sh encoding: 'UTF-8', label: 'cortx-setup', script: '''
-                if [ -f "./devops/rpms/lr-cli/build_python_cortx_setup.sh" ]; then
-                    bash ./devops/rpms/lr-cli/build_python_cortx_setup.sh -vv --out-dir /root/rpmbuild/RPMS/x86_64/ --pkg-ver ${CUSTOM_CI_BUILD_ID}_git$(git rev-parse --short HEAD)
-                else
-                    echo "cortx-setup package creation is not implemented"
-                fi        
-                '''
 
                 sh encoding: 'UTF-8', label: 'cortx-provisioner', script: '''
                 if [ -f "./jenkins/build.sh" ]; then
                     bash ./jenkins/build.sh -v 2.0.0 -b ${CUSTOM_CI_BUILD_ID}
                 else
                     echo "cortx-provisioner package creation is not implemented"
-                fi        
+                fi
                 '''
             }
         }

--- a/jenkins/internal-ci/centos-7.9.2009/branch/provisioner.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/branch/provisioner.groovy
@@ -1,15 +1,15 @@
 #!/usr/bin/env groovy
-pipeline { 
+pipeline {
     agent {
         node {
             label "docker-${os_version}-node"
         }
     }
-    
+
     triggers {
         pollSCM '*/5 * * * *'
     }
-    
+
     environment {
         version = "2.0.0"
         env = "dev"
@@ -21,10 +21,10 @@ pipeline {
     options {
         timeout(time: 120, unit: 'MINUTES')
         timestamps()
-        ansiColor('xterm') 
-        disableConcurrentBuilds()   
+        ansiColor('xterm')
+        disableConcurrentBuilds()
     }
-    
+
     stages {
 
         stage('Checkout') {
@@ -37,34 +37,13 @@ pipeline {
         stage('Build') {
             steps {
                 script { build_stage = env.STAGE_NAME }
-                sh encoding: 'utf-8', label: 'Provisioner RPMS', returnStdout: true, script: """
-                    sh ./devops/rpms/buildrpm.sh -g \$(git rev-parse --short HEAD) -e $version -b ${BUILD_NUMBER}
-                """
-                sh encoding: 'utf-8', label: 'Provisioner CLI RPMS', returnStdout: true, script: """
-                    sh ./cli/buildrpm.sh -g \$(git rev-parse --short HEAD) -e $version -b ${BUILD_NUMBER}
-                """
-                sh encoding: 'UTF-8', label: 'cortx-setup', script: """
-                if [ -f "./devops/rpms/node_cli/node_cli_buildrpm.sh" ]; then
-                    sh ./devops/rpms/node_cli/node_cli_buildrpm.sh -g \$(git rev-parse --short HEAD) -e $version -b ${BUILD_NUMBER}
-                else
-                    echo "node_cli package creation is not implemented"
-                fi
-                """
-                
-                sh encoding: 'UTF-8', label: 'api', script: '''
-                    bash ./devops/rpms/api/build_python_api.sh -vv --out-dir /root/rpmbuild/RPMS/x86_64/ --pkg-ver ${BUILD_NUMBER}_git$(git rev-parse --short HEAD)
-                '''
-
-                sh encoding: 'UTF-8', label: 'cortx-setup', script: '''
-                    bash ./devops/rpms/lr-cli/build_python_cortx_setup.sh -vv --out-dir /root/rpmbuild/RPMS/x86_64/ --pkg-ver ${BUILD_NUMBER}_git$(git rev-parse --short HEAD)
-                '''
 
                 sh encoding: 'UTF-8', label: 'cortx-provisioner', script: '''
                 if [ -f "./jenkins/build.sh" ]; then
                     bash ./jenkins/build.sh -v 2.0.0 -b ${BUILD_NUMBER}
                 else
                     echo "cortx-provisioner package creation is not implemented"
-                fi  
+                fi
             }
         }
 
@@ -82,7 +61,7 @@ pipeline {
                 '''
             }
         }
-            
+
         stage ('Tag last_successful') {
             steps {
                 script { build_stage = env.STAGE_NAME }
@@ -106,7 +85,7 @@ pipeline {
             }
         }
     stage('Update Jira') {
-        when { expression { return env.release_build != null } }    
+        when { expression { return env.release_build != null } }
         steps {
             script { build_stage=env.STAGE_NAME }
                 script {
@@ -136,18 +115,18 @@ pipeline {
                     }
                 }
         }
-    }    
+    }
     }
 
     post {
-        always {                
+        always {
             script {
-                env.release_build = (env.release_build != null) ? env.release_build : "" 
+                env.release_build = (env.release_build != null) ? env.release_build : ""
                 env.release_build_location = (env.release_build_location != null) ? env.release_build_location : ""
                 env.component = (env.component).capitalize()
                 env.build_stage = "${build_stage}"
 
-                env.vm_deployment = (env.deployVMURL != null) ? env.deployVMURL : "" 
+                env.vm_deployment = (env.deployVMURL != null) ? env.deployVMURL : ""
                 if ( env.deployVMStatus != null && env.deployVMStatus != "SUCCESS" && manager.build.result.toString() == "SUCCESS" ) {
                     manager.buildUnstable()
                 }

--- a/jenkins/internal-ci/centos-7.9.2009/branch/provisioner.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/branch/provisioner.groovy
@@ -52,7 +52,6 @@ pipeline {
             steps {
             sh encoding: 'utf-8', label: 'Provisioner RPMS', returnStdout: true, script: """
                 mkdir -p $build_upload_dir/$BUILD_NUMBER
-                cp /root/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir/$BUILD_NUMBER
                 shopt -s extglob
                 if ls ./dist/*.rpm; then
                     cp ./dist/!(*.src.rpm|*.tar.gz) $build_upload_dir/$BUILD_NUMBER


### PR DESCRIPTION
# Problem Statement
- Remove obsolete Provisioner RPM's from Kubernetes build generation. This reduces build time and disk usage. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - 
        Tested using 
         http://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/centos-7.9/job/nightly-k8-custom-ci/547/console
        http://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/centos-7.9/job/cortx-all-image-custom-ci/1471/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide