### PR TITLE
EOS-26146 Add 60s delay before checking hctl status

### DIFF
--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -278,7 +278,9 @@ echo "---------------------------------------[ POD Status ]---------------------
 echo "-----------[ All POD's are not in running state. Marking deployment as failed. Please check problematic pod events using kubectl describe pod <pod name> ]--------------------"
       exit 1
     fi
-echo "---------------------------------------[ hctl status ]--------------------------------------"
+echo "-----------[ Sleeping for 1min before checking hctl status.... ]--------------------"
+    sleep 60  
+echo "---------------------------------------[ hctl status ]-----------------------------------------"
     SECONDS=0
     date
     while [[ SECONDS -lt 1200 ]] ; do


### PR DESCRIPTION
# Problem Statement
- Add 60s delay before checking hctl status. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide