### PR TITLE
EOS-26146 - Promote cortx-all image from local repo after deployment validation instead in nightly image generation.

### DIFF
--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -16,6 +16,7 @@ pipeline {
         CORTX_RE_REPO = "https://github.com/Seagate/cortx-re/"
         DOCKER_IMAGE_LOCATION = "https://github.com/Seagate/cortx-re/pkgs/container/cortx-all"
         LOCAL_REG_CRED = credentials('local-registry-access')
+        GITHUB_CRED = credentials('shailesh-github')
     }
     parameters {
         string(name: 'CORTX_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-latest-kubernetes', description: 'CORTX-ALL image', trim: true)
@@ -97,11 +98,12 @@ pipeline {
                    systemctl status docker
                    /usr/local/bin/docker-compose --version
                    echo 'y' | docker image prune
-                   docker pull $CORTX_IMAGE
-                   docker tag $CORTX_IMAGE cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci-deploy-tested
                    
-                   docker login cortx-docker.colo.seagate.com -u ${LOCAL_REG_CRED_USR} -p ${LOCAL_REG_CRED_PSW}
-                   docker push cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci-deploy-tested
+                   docker pull $CORTX_IMAGE
+                   docker tag $CORTX_IMAGE ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci-deploy-tested
+                   
+                   docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
+                   docker push ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci-deploy-tested
                 """
             }
         }

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -23,11 +23,6 @@ pipeline {
             description: 'Email Notification Recipients ',
             name: 'EMAIL_RECIPIENTS'
         )
-        choice (
-            choices: ['ghcr.io', 'cortx-docker.colo.seagate.com'],
-            description: 'Docker Registry to be used',
-            name: 'DOCKER_REGISTRY'
-        )
     }
     // Please configure hosts,SNS and DIX parameter in Jenkins job configuration.
     stages {

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -15,6 +15,7 @@ pipeline {
         CORTX_RE_BRANCH = "kubernetes"
         CORTX_RE_REPO = "https://github.com/Seagate/cortx-re/"
         DOCKER_IMAGE_LOCATION = "https://github.com/Seagate/cortx-re/pkgs/container/cortx-all"
+        LOCAL_REG_CRED = credentials('local-registry-access')
     }
     parameters {
         string(name: 'CORTX_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-latest-kubernetes', description: 'CORTX-ALL image', trim: true)
@@ -85,7 +86,7 @@ pipeline {
             }
         }
 
-        stage('Prerequisite') {
+        stage('Push Image to GitHub') {
             agent {
                 node {
                 label 'docker-image-builder-centos-7.9.2009'
@@ -96,6 +97,11 @@ pipeline {
                    systemctl status docker
                    /usr/local/bin/docker-compose --version
                    echo 'y' | docker image prune
+                   docker pull $CORTX_IMAGE
+                   docker tag $CORTX_IMAGE cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci-deploy-tested
+                   
+                   docker login cortx-docker.colo.seagate.com -u ${LOCAL_REG_CRED_USR} -p ${LOCAL_REG_CRED_PSW}
+                   docker push cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci-deploy-tested
                 """
             }
         }

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -17,6 +17,8 @@ pipeline {
         DOCKER_IMAGE_LOCATION = "https://github.com/Seagate/cortx-re/pkgs/container/cortx-all"
         LOCAL_REG_CRED = credentials('local-registry-access')
         GITHUB_CRED = credentials('shailesh-github')
+        VERSION = "2.0.0"
+        GITHUB_TAG_SUFFIX = "custom-ci" 
     }
     parameters {
         string(name: 'CORTX_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-latest-kubernetes', description: 'CORTX-ALL image', trim: true)
@@ -100,15 +102,15 @@ pipeline {
                    echo 'y' | docker image prune
    
                    docker pull $CORTX_IMAGE
-                   docker tag $CORTX_IMAGE ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci
-                   docker tag $CORTX_IMAGE ghcr.io/seagate/cortx-all:2.0.0-latest-cutom-ci
+                   docker tag $CORTX_IMAGE ghcr.io/seagate/cortx-all:$VERSION-$BUILD_NUMBER-$GITHUB_TAG_SUFFIX
+                   docker tag $CORTX_IMAGE ghcr.io/seagate/cortx-all:$VERSION-latest-$GITHUB_TAG_SUFFIX
                    
                    docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
-                   docker push ghcr.io/seagate/cortx-all:2.0.0-latest-cutom-ci 
-                   docker push ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci
+                   docker push ghcr.io/seagate/cortx-all:$VERSION-latest-$GITHUB_TAG_SUFFIX 
+                   docker push ghcr.io/seagate/cortx-all:$VERSION-$BUILD_NUMBER-$GITHUB_TAG_SUFFIX
 
-                   docker rmi ghcr.io/seagate/cortx-all:2.0.0-latest-cutom-ci
-                   docker rmi ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci
+                   docker rmi ghcr.io/seagate/cortx-all:$VERSION-latest-$GITHUB_TAG_SUFFIX
+                   docker rmi ghcr.io/seagate/cortx-all:$VERSION-$BUILD_NUMBER-$GITHUB_TAG_SUFFIX
                 """
             }
         }

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -54,45 +54,21 @@ pipeline {
                 }
             }
         }
-        stage ("Build Creation and Cluster Cleanup") {
-            parallel {
-                stage ("Build Creation") {
-                    steps {
-                        script { build_stage = env.STAGE_NAME }
-                        script {
-                            def customCI = build job: '/GitHub-custom-ci-builds/centos-7.9/nightly-k8-custom-ci', wait: true,
-                            parameters: [
-                                string(name: 'CSM_AGENT_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'CSM_WEB_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'HARE_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'HA_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'MOTR_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'PRVSNR_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'S3_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'SSPL_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'CORTX_UTILS_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'CORTX_RE_BRANCH', value: "${COMPONENT_BRANCH}"),
-                                string(name: 'THIRD_PARTY_RPM_VERSION', value: "cortx-2.0-k8")
-                            ]
-                            env.custom_ci_build_id = customCI.rawBuild.id
-                        }
-                    }
-                }
-                stage ("Cluster Cleanup") {
-                    steps {
-                        script { build_stage = env.STAGE_NAME }
-                        script {
-                            build job: '/Cortx-kubernetes/destroy-cortx-cluster', wait: true,
-                            parameters: [
-                                string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                                string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_REPO}"),
-                                text(name: 'hosts', value: "${hosts}")
-                            ]
-                        }
-                    }
+
+        stage ("Cluster Cleanup") {
+            steps {
+                script { build_stage = env.STAGE_NAME }
+                script {
+                    build job: '/Cortx-kubernetes/destroy-cortx-cluster', wait: true,
+                    parameters: [
+                        string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
+                        string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_REPO}"),
+                        text(name: 'hosts', value: "${hosts}")
+                    ]
                 }
             }
         }
+
         stage ("CORTX-ALL image creation") {
             steps {
                 script { build_stage = env.STAGE_NAME }

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -98,12 +98,17 @@ pipeline {
                    systemctl status docker
                    /usr/local/bin/docker-compose --version
                    echo 'y' | docker image prune
-                   
+   
                    docker pull $CORTX_IMAGE
-                   docker tag $CORTX_IMAGE ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci-deploy-tested
+                   docker tag $CORTX_IMAGE ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci
+                   docker tag $CORTX_IMAGE ghcr.io/seagate/cortx-all:2.0.0-latest-cutom-ci
                    
                    docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
-                   docker push ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci-deploy-tested
+                   docker push ghcr.io/seagate/cortx-all:2.0.0-latest-cutom-ci 
+                   docker push ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci
+
+                   docker rmi ghcr.io/seagate/cortx-all:2.0.0-latest-cutom-ci
+                   docker rmi ghcr.io/seagate/cortx-all:2.0.0-$BUILD_NUMBER-cutom-ci
                 """
             }
         }

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -85,6 +85,20 @@ pipeline {
             }
         }
 
+        stage('Prerequisite') {
+            agent {
+                node {
+                label 'docker-image-builder-centos-7.9.2009'
+                }
+            }
+           steps {
+                sh encoding: 'utf-8', label: 'Validate Docker pre-requisite', script: """
+                   systemctl status docker
+                   /usr/local/bin/docker-compose --version
+                   echo 'y' | docker image prune
+                """
+            }
+        }
     }
 
     post {

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -114,6 +114,32 @@ pipeline {
                 """
             }
         }
+
+        stage ("QA Sanity K8S") {
+            steps {
+                script {
+                    catchError(stageResult: 'FAILURE') {
+                        def qaSanity = build job: '/QA-Sanity-Multinode-K8s', wait: true, propagate: false,
+                        parameters: [
+                            string(name: 'M_NODE', value: "${env.master_node}"),
+                            password(name: 'HOST_PASS', value: "${env.hostpasswd}"),
+                            string(name: 'CORTX_IMAGE', value: "${CORTX_IMAGE}"),
+                            string(name: 'NUM_NODES', value: "${env.numberofnodes}")
+                        ]
+                        env.Sanity_Failed = qaSanity.buildVariables.Sanity_Failed
+                        env.sanity_result = qaSanity.currentResult
+                        env.Current_TP = qaSanity.buildVariables.Current_TP
+                        env.Health = qaSanity.buildVariables.Health
+                        env.qaSanity_status = qaSanity.currentResult
+                        env.qaSanityK8sJob_URL = qaSanity.absoluteUrl
+                    }
+                    copyArtifacts filter: 'log/*report.xml', fingerprintArtifacts: true, flatten: true, optional: true, projectName: 'QA-Sanity-Multinode-K8s', selector: lastCompleted(), target: 'log/'
+                    copyArtifacts filter: 'log/*report.html', fingerprintArtifacts: true, flatten: true, optional: true, projectName: 'QA-Sanity-Multinode-K8s', selector: lastCompleted(), target: 'log/'
+                    copyArtifacts filter: 'log/*report.xml', fingerprintArtifacts: true, flatten: true, optional: true, projectName: 'QA-Sanity-Multinode-K8s', selector: lastCompleted(), target: ''
+                    copyArtifacts filter: 'log/*report.html', fingerprintArtifacts: true, flatten: true, optional: true, projectName: 'QA-Sanity-Multinode-K8s', selector: lastCompleted(), target: ''
+                }
+            }
+        }
     }
 
     post {


### PR DESCRIPTION
# Problem Statement
- We are generating nightly images and storing them in GitHub. This sometimes causes faulty images (deployment not working) stored in GitHub. This PR change will promote cortx-all image from local repo after deployment validation instead in nightly image generation

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested with - http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/nightly-ci-cd/257/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide