### PR TITLE
EOS-23696 - Upgrade PyYAML package to 5.4.1

### DIFF
--- a/docker/cortx-deploy/python_requirements.txt
+++ b/docker/cortx-deploy/python_requirements.txt
@@ -24,7 +24,7 @@ pyinotify==0.9.6
 python-consul==1.1.0
 python-crontab==2.5.1
 python-daemon==2.2.4
-PyYAML==5.1.2
+PyYAML==5.4.1
 requests==2.25.1
 schematics==2.1.0
 secure==0.2.1

--- a/docker/cortx-deploy/third-party-rpms.txt
+++ b/docker/cortx-deploy/third-party-rpms.txt
@@ -18,7 +18,6 @@ pkgconfig-0.27.1 #cortx-s3srever
 log4cxx_cortx-0.10.0 #cortx-s3srever
 python36-ldap-3.1.0 #cortx-s3srever
 python36-pika-0.10.0 #cortx-s3srever
-PyYAML-3.10 #cortx-s3srever
 hiredis-0.12.1 #cortx-s3srever
 sshpass
 sudo

--- a/scripts/third-party-rpm/python_requirements.txt
+++ b/scripts/third-party-rpm/python_requirements.txt
@@ -22,7 +22,7 @@ pyinotify==0.9.6
 python-consul==1.1.0
 python-crontab==2.5.1
 python-daemon==2.2.4
-PyYAML==5.1.2
+PyYAML==5.4.1
 requests==2.25.1
 schematics==2.1.0
 secure==0.2.1


### PR DESCRIPTION
Signed-off-by: Swanand S Gadre <swanand.s.gadre@seagate.com>

### Specification of requested package

Details | Values
------ | ------
Package Name  | PyYAML
Version | 5.4.1
license | MIT
Source  | https://github.com/yaml/pyyaml


### Please add below details about package

* [X] Purpose of using new SW ?
PyYAML library that is current used is version 5.1.2
It needs to be upgraded to 5.4.1

* [X] Location of the source code of new opensource SW ?

https://github.com/yaml/pyyaml

* [X] Did you evaluate existing SW and confirm they do not serve the purpose ? If yes, include the comparison. If no, why ?

Yes, detailed testing is conducted and attached as a document to JIRA Bug -> https://jts.seagate.com/browse/EOS-23696
* [X] Who is building it or how it gets built ? If yes, Which component/rpm will it be included ? i.e. name of the rpm which includes SW.


* [X] Download location of opensource software package ?

https://pypi.org/project/PyYAML/5.4.1/#files
* [X] Who will be supporting this package ?

Its opensource python package.
* [X] Is there a configuration required for this? Who will be configuring it ?

No configuration required
* [X] Which component is responsible for deploying on nodes ?

Provisioner and services team

* [X] What is the licensing policy ? Is it approved by legal ? 

MIT license, it was the same license as used by PyYAML 5.1.2