### PR TITLE
EOS-26885-build motr rpm without kernel package from cortx-build image

### DIFF
--- a/docker/cortx-build/Makefile
+++ b/docker/cortx-build/Makefile
@@ -87,10 +87,9 @@ _cortx-motr_build:
 	
 	pushd cortx-workspace/cortx-motr && \
 		echo "***************  Building cortx-motr RPMS from $$(git rev-parse --short HEAD) *********************" && \
-		KERNEL=/lib/modules/$$(yum list installed kernel | tail -n1 | awk '{ print $$2 }').x86_64/build && \
 		./autogen.sh || \
 		./autogen.sh && \
-		./configure --with-linux=$$KERNEL && \
+		./configure --with-user-mode-only && \
 		export build_number=${BUILD_ID} && \
 		make rpms && \
 		rm -rf ${RPM_DIR}/cortx-motr*.rpm && \


### PR DESCRIPTION
Signed-off-by: nikhilpatil2995 <nikhil.patil@seagate.com>

# Problem Statement
- EOS-26885-build motr rpm without kernel package from cortx-build image

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide