### PR TITLE
EOS-26146 - Add support to use internal OS repositories.

### DIFF
--- a/docker/cortx-deploy/build.sh
+++ b/docker/cortx-deploy/build.sh
@@ -34,7 +34,7 @@ PROJECT="seagate"
 ARTFACT_URL="http://cortx-storage.colo.seagate.com/releases/cortx/github/"
 SERVICE=cortx-all
 
-while getopts "b:p:t:r:h:" opt; do
+while getopts "b:p:t:r:e:h:" opt; do
     case $opt in
         b ) BUILD=$OPTARG;;
         p ) DOCKER_PUSH=$OPTARG;;

--- a/jenkins/automation/kubernetes/cortx-all-image.groovy
+++ b/jenkins/automation/kubernetes/cortx-all-image.groovy
@@ -87,11 +87,11 @@ pipeline {
                 sh encoding: 'utf-8', label: 'Build cortx-all docker image', script: """
                     pushd ./docker/cortx-deploy
                         if [ $GITHUB_PUSH == yes ] && [ $TAG_LATEST == yes ];then
-                                sh ./build.sh -b $BUILD -p yes -t yes -r $DOCKER_REGISTRY
+                                sh ./build.sh -b $BUILD -p yes -t yes -r $DOCKER_REGISTRY -e internal-ci
                         elif [ $GITHUB_PUSH == yes ] && [ $TAG_LATEST == no ]; then
-                                 sh ./build.sh -b $BUILD -p yes -t no -r $DOCKER_REGISTRY
+                                 sh ./build.sh -b $BUILD -p yes -t no -r $DOCKER_REGISTRY -e internal-ci
                         else
-                                 sh ./build.sh -b $BUILD -p no
+                                 sh ./build.sh -b $BUILD -p no -e internal-ci
                         fi
                     popd
                     docker logout  


### PR DESCRIPTION
# Problem Statement
- Use internal OS and EPEL repositries for building cortx-all image.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability . Tested using http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/cortx-all-docker-image-shailesh-test/21
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide