### PR TITLE
EOS-27074 - Given a choice to user to build motr rpm using kernel mode or user mode (main branch)

### DIFF
--- a/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
@@ -58,6 +58,12 @@ pipeline {
 			description: 'Third Party RPM Version to use.'
 		)
 
+        choice(
+            name: 'MOTR_BUILD_MODE',
+            choices: ['user-mode', 'kernel'],
+            description: 'Build motr rpm using kernel or user-mode.'
+        )
+
 		choice(
 			name: 'THIRD_PARTY_PYTHON_VERSION',
 			choices: ['cortx-2.0', 'custom'],
@@ -147,6 +153,7 @@ pipeline {
 										parameters: [
 														string(name: 'MOTR_URL', value: "${MOTR_URL}"),
 														string(name: 'MOTR_BRANCH', value: "${MOTR_BRANCH}"),
+                                                        string(name: 'MOTR_BUILD_MODE', value: "${MOTR_BUILD_MODE}"),
 														string(name: 'S3_URL', value: "${S3_URL}"),
 														string(name: 'S3_BRANCH', value: "${S3_BRANCH}"),
 														string(name: 'HARE_URL', value: "${HARE_URL}"),

--- a/jenkins/custom-ci/centos-7.9.2009/motr.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/motr.groovy
@@ -7,7 +7,7 @@ pipeline {
 	}
 
 	options {
-		timeout(time: 120, unit: 'MINUTES')
+		timeout(time: 60, unit: 'MINUTES')
 		timestamps()
 		buildDiscarder(logRotator(daysToKeepStr: '5', numToKeepStr: '10'))
 		parallelsAlwaysFailFast()
@@ -65,10 +65,9 @@ pipeline {
 				script { build_stage = env.STAGE_NAME }
 						sh label: '', script: '''
 						rm -rf /root/rpmbuild/RPMS/x86_64/*.rpm
-						./autogen.sh
 						KERNEL=/lib/modules/$(yum list installed kernel | tail -n1 | awk '{ print $2 }').x86_64/build
+						./autogen.sh
 						./configure --with-linux=$KERNEL
-			
 						export build_number=${CUSTOM_CI_BUILD_ID}
 						make rpms
 					'''

--- a/jenkins/custom-ci/centos-7.9.2009/motr.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/motr.groovy
@@ -7,7 +7,7 @@ pipeline {
 	}
 
 	options {
-		timeout(time: 60, unit: 'MINUTES')
+		timeout(time: 120, unit: 'MINUTES')
 		timestamps()
 		buildDiscarder(logRotator(daysToKeepStr: '5', numToKeepStr: '10'))
 		parallelsAlwaysFailFast()
@@ -17,7 +17,6 @@ pipeline {
 	parameters {  
         string(name: 'MOTR_URL', defaultValue: 'https://github.com/Seagate/cortx-motr', description: 'Branch for Motr.')
 		string(name: 'MOTR_BRANCH', defaultValue: 'stable', description: 'Branch for Motr.')
-		string(name: 'MOTR_BUILD_MODE', defaultValue: 'user-mode', description: 'Build motr rpm using kernel or user-mode.', trim: true)
 		string(name: 'S3_URL', defaultValue: 'https://github.com/Seagate/cortx-s3server', description: 'Branch for S3Server')
 		string(name: 'S3_BRANCH', defaultValue: 'stable', description: 'Branch for S3Server')
 		string(name: 'HARE_URL', defaultValue: 'https://github.com/Seagate/cortx-hare', description: 'Branch to be used for Hare build.')
@@ -66,14 +65,10 @@ pipeline {
 				script { build_stage = env.STAGE_NAME }
 						sh label: '', script: '''
 						rm -rf /root/rpmbuild/RPMS/x86_64/*.rpm
-						KERNEL=/lib/modules/$(yum list installed kernel | tail -n1 | awk '{ print $2 }').x86_64/build
 						./autogen.sh
-						if [ "${MOTR_BUILD_MODE}" == "kernel" ]; then
-							KERNEL=/lib/modules/$(yum list installed kernel | tail -n1 | awk '{ print $2 }').x86_64/build
-							./configure --with-linux=$KERNEL
-						else
-							./configure --with-user-mode-only
-						fi
+						KERNEL=/lib/modules/$(yum list installed kernel | tail -n1 | awk '{ print $2 }').x86_64/build
+						./configure --with-linux=$KERNEL
+			
 						export build_number=${CUSTOM_CI_BUILD_ID}
 						make rpms
 					'''

--- a/jenkins/custom-ci/centos-7.9.2009/motr.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/motr.groovy
@@ -17,6 +17,7 @@ pipeline {
 	parameters {  
         string(name: 'MOTR_URL', defaultValue: 'https://github.com/Seagate/cortx-motr', description: 'Branch for Motr.')
 		string(name: 'MOTR_BRANCH', defaultValue: 'stable', description: 'Branch for Motr.')
+		string(name: 'MOTR_BUILD_MODE', defaultValue: 'user-mode', description: 'Build motr rpm using kernel or user-mode.', trim: true)
 		string(name: 'S3_URL', defaultValue: 'https://github.com/Seagate/cortx-s3server', description: 'Branch for S3Server')
 		string(name: 'S3_BRANCH', defaultValue: 'stable', description: 'Branch for S3Server')
 		string(name: 'HARE_URL', defaultValue: 'https://github.com/Seagate/cortx-hare', description: 'Branch to be used for Hare build.')
@@ -67,7 +68,12 @@ pipeline {
 						rm -rf /root/rpmbuild/RPMS/x86_64/*.rpm
 						KERNEL=/lib/modules/$(yum list installed kernel | tail -n1 | awk '{ print $2 }').x86_64/build
 						./autogen.sh
-						./configure --with-linux=$KERNEL
+						if [ "${MOTR_BUILD_MODE}" == "kernel" ]; then
+							KERNEL=/lib/modules/$(yum list installed kernel | tail -n1 | awk '{ print $2 }').x86_64/build
+							./configure --with-linux=$KERNEL
+						else
+							./configure --with-user-mode-only
+						fi
 						export build_number=${CUSTOM_CI_BUILD_ID}
 						make rpms
 					'''


### PR DESCRIPTION
Signed-off-by: nikhilpatil2995 <nikhil.patil@seagate.com>

# Problem Statement
- EOS-27074 - Given a choice to user to build motr rpm using kernel mode or user mode

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide