### PR TITLE
EOS-26146 Modify get_tag function to use new provisioner package name

### DIFF
--- a/docker/cortx-deploy/build.sh
+++ b/docker/cortx-deploy/build.sh
@@ -63,13 +63,12 @@ echo "Building $SERVICE image from $BUILD_URL"
 sleep 5
 
 function get_git_hash {
-
-for component in cortx-py-utils cortx-s3server cortx-motr cortx-hare
+sed -i '/KERNEL/d' RELEASE.INFO
+for component in cortx-py-utils cortx-s3server cortx-motr cortx-hare cortx-provisioner
 do
-    echo $component:"$(awk -F['_'] '/'$component'-2.0.0/ { print $2 }' RELEASE.INFO | cut -d. -f1 | sed 's/git//g')",
+    echo $component:"$(awk -F['_'] '/'$component'-'$VERSION'/ { print $2 }' RELEASE.INFO | cut -d. -f1 | sed 's/git//g')",
 done
-echo cortx-csm_agent:"$(awk -F['_'] '/cortx-csm_agent-2.0.0/ { print $3 }' RELEASE.INFO | cut -d. -f1)",
-echo cortx-prvsnr:"$(awk -F['.'] '/cortx-prvsnr-2.0.0/ { print $4 }' RELEASE.INFO | sed 's/git//g')",
+echo cortx-csm_agent:"$(awk -F['_'] '/cortx-csm_agent-'$VERSION'/ { print $3 }' RELEASE.INFO | cut -d. -f1)",
 }
 
 


### PR DESCRIPTION
# Problem Statement
- Modified get_tag function to use the new provisioner package name. without this change version is not displayed properly.
without change
```
[root@ssc-vm-rhev4-0707 cortx-deploy]# docker inspect --format='{{ index .Config.Labels "org.opencontainers.image.revision"}}' ghcr.io/seagate/cortx-all:2.0.0-latest-custom-ci
cortx-py-utils:3f45b5c, cortx-s3server:4022a4dc, cortx-motr:ae659ec1 ae659ec1, cortx-hare:da6be5a, cortx-csm_agent:308527f2, cortx-prvsnr:,
[root@ssc-vm-rhev4-0707 cortx-deploy]#
```
After change
```
[root@ssc-vm-rhev4-0707 cortx-deploy]# docker inspect --format='{{ index .Config.Labels "org.opencontainers.image.revision"}}' cortx-all:2.0.0-90-kubernetes
cortx-py-utils:3f45b5c, cortx-s3server:4022a4dc, cortx-motr:ae659ec1, cortx-hare:da6be5a, cortx-provisioner:a851e7b5, cortx-csm_agent:d0779dab,
[root@ssc-vm-rhev4-0707 cortx-deploy]#
```


# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested locally
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide