### PR TITLE
EOS-26147 - Use separate stage for IO Test

### DIFF
--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -72,6 +72,19 @@ pipeline {
                 '''
             }
         }
+
+        stage ('IO Sanity Test') {
+            steps {
+                script { build_stage = env.STAGE_NAME }
+                sh label: 'Deploy CORTX Components', script: '''
+                    pushd solutions/kubernetes/
+                        echo $hosts | tr ' ' '\n' > hosts
+                        cat hosts
+                        ./cortx-deploy.sh --io-test
+                    popd
+                '''
+            }
+        }
     }
 
     post {

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -27,7 +27,7 @@ SSH_KEY_FILE=/root/.ssh/id_rsa
 
 function usage(){
     cat << HEREDOC
-Usage : $0 [--third-party, --cortx-cluster, --destroy-cluster]
+Usage : $0 [--third-party, --cortx-cluster, --destroy-cluster, --io-test]
 where,
     --third-party - Deploy third-party components
     --cortx-cluster - Deploy Third-Party and CORTX components

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -32,6 +32,7 @@ where,
     --third-party - Deploy third-party components
     --cortx-cluster - Deploy Third-Party and CORTX components
     --destroy-cluster  - Destroy CORTX cluster
+    --io-test - Perform IO sanity test
 HEREDOC
 }
 
@@ -111,11 +112,6 @@ EOF
         echo "---------------------------------------[ Print Cluster Status ]----------------------------------------------"
         rm -rf /var/tmp/cortx-cluster-status.txt
         ssh -o 'StrictHostKeyChecking=no' "$master_node" '/var/tmp/cortx-deploy-functions.sh --status' | tee /var/tmp/cortx-cluster-status.txt
-
-        # IO test
-        add_separator Setting up IO testing
-        scp -q io-testing.sh s3-client-setup.sh "$master_node":/var/tmp/
-        ssh -o 'StrictHostKeyChecking=no' "$master_node" '/var/tmp/cortx-deploy-functions.sh --io-test'
         done
 }
 
@@ -135,6 +131,20 @@ function destroy-cluster(){
         ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" "/var/tmp/cortx-deploy-functions.sh --destroy"
         echo "--------------------------------[ Print Kubernetes Cluster Status after Cleanup]----------------------------------------------"
         ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" 'kubectl get pods -o wide' | tee /var/tmp/cortx-cluster-status.txt	
+}
+
+function io-test(){
+    validation
+    generate_rsa_key
+    nodes_setup
+    	MASTER_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
+    for master_node in $MASTER_NODE
+        do
+        # IO test
+        add_separator Setting up IO testing
+        scp -q io-testing.sh s3-client-setup.sh "$master_node":/var/tmp/
+        ssh -o 'StrictHostKeyChecking=no' "$master_node" '/var/tmp/cortx-deploy-functions.sh --io-test'
+        done
 }
 
 
@@ -160,6 +170,9 @@ case $ACTION in
     ;;
     --destroy-cluster)
         destroy-cluster
+    ;;
+    --io-test)
+        io-test
     ;;
     *)
         echo "ERROR : Please provide valid option"


### PR DESCRIPTION
# Problem Statement
- Use separate stage for IO Test. Sometimes IO test takes more time than expected. Hence created a separate stage for it. This will also enable us to run the IO tests on the already deployed cluster. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested using - http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/setup-cortx-cluster/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide