### PR TITLE
EOS-26654 Added IO sanity test and collect CORTX support bundle on failure.

### DIFF
--- a/jenkins/automation/kubernetes/deploy-cortx-k8-cluster.groovy
+++ b/jenkins/automation/kubernetes/deploy-cortx-k8-cluster.groovy
@@ -91,7 +91,7 @@ pipeline {
         stage ('IO Sanity Test') {
             steps {
                 script { build_stage = env.STAGE_NAME }
-                sh label: 'Deploy CORTX Components', script: '''
+                sh label: 'Perform IO Sanity Test', script: '''
                     pushd solutions/kubernetes/
                         echo $hosts | tr ' ' '\n' > hosts
                         cat hosts

--- a/jenkins/automation/kubernetes/deploy-cortx-k8-cluster.groovy
+++ b/jenkins/automation/kubernetes/deploy-cortx-k8-cluster.groovy
@@ -87,6 +87,19 @@ pipeline {
                 '''
             }
         }
+
+        stage ('IO Sanity Test') {
+            steps {
+                script { build_stage = env.STAGE_NAME }
+                sh label: 'Deploy CORTX Components', script: '''
+                    pushd solutions/kubernetes/
+                        echo $hosts | tr ' ' '\n' > hosts
+                        cat hosts
+                        ./cortx-deploy.sh --io-test
+                    popd
+                '''
+            }
+        }
     }
 
     post {
@@ -147,6 +160,19 @@ pipeline {
                 // Archive Deployment artifacts in jenkins build
                 archiveArtifacts artifacts: "artifacts/*.*", onlyIfSuccessful: false, allowEmptyArchive: true 
             }    
+        }
+
+        failure {
+            sh label: 'Collect CORTX support bundle logs in artifacts', script: '''
+            mkdir -p artifacts
+            pushd solutions/kubernetes/
+                ./cortx-deploy.sh --support-bundle
+                HOST_FILE=$PWD/hosts
+                MASTER_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
+                LOG_FILE=$(ssh -o 'StrictHostKeyChecking=no' $MASTER_NODE 'ls -t /root/deploy-scripts/k8_cortx_cloud | grep logs-cortx-cloud | grep .tar | head -1')
+                scp -q "$MASTER_NODE":/root/deploy-scripts/k8_cortx_cloud/$LOG_FILE $WORKSPACE/artifacts/
+            popd
+            '''
         }  
     }
 }

--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -76,7 +76,7 @@ pipeline {
         stage ('IO Sanity Test') {
             steps {
                 script { build_stage = env.STAGE_NAME }
-                sh label: 'Deploy CORTX Components', script: '''
+                sh label: 'Perform IO Sanity Test', script: '''
                     pushd solutions/kubernetes/
                         echo $hosts | tr ' ' '\n' > hosts
                         cat hosts


### PR DESCRIPTION
Signed-off-by: Nitish Singh <nitish.singh@seagate.com>

# Problem Statement
- Add IO sanity test and collect CORTX support bundle on failure.

# Design
-  Added IO sanity test and collect CORTX support bundle on failure.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- IO Testing (3 node): http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_deploy_k8s_cortx_cluster/44/console
- CORTX support bundle (3 node): http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_deploy_k8s_cortx_cluster/45/console
- IO Testing (single node): http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_deploy_k8s_cortx_cluster/43/console

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide