### PR TITLE
EOS-27120 Remove cortx-prereq package installation from csm-agent build process.

### DIFF
--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -29,7 +29,7 @@ pipeline {
         string(name: 'CUSTOM_CI_BUILD_ID', defaultValue: '0', description: 'Custom CI Build Number')
         string(name: 'CORTX_UTILS_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for CORTX Utils', trim: true)
         string(name: 'CORTX_UTILS_URL', defaultValue: 'https://github.com/Seagate/cortx-utils', description: 'CORTX Utils Repository URL', trim: true)
-        string(name: 'THIRD_PARTY_PYTHON_VERSION', defaultValue: 'custom', description: 'Third Party Python Version to use', trim: true)
+        string(name: 'THIRD_PARTY_PYTHON_VERSION', defaultValue: 'cortx-2.0', description: 'Third Party Python Version to use', trim: true)
     }    
 
 

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -14,8 +14,6 @@ pipeline {
         release_tag = "custom-build-$CUSTOM_CI_BUILD_ID"
         build_upload_dir = "$release_dir/github/integration-custom-ci/$os_version/$release_tag/cortx_iso"
         python_deps = "${THIRD_PARTY_PYTHON_VERSION == 'cortx-2.0' ? "python-packages-2.0.0-latest" : THIRD_PARTY_PYTHON_VERSION == 'custom' ?  "python-packages-2.0.0-custom" : "python-packages-2.0.0-stable"}"
-        third_party_rpm_dir = "${THIRD_PARTY_RPM_VERSION == 'cortx-2.0' ? "$os_version-2.0.0-latest" : THIRD_PARTY_RPM_VERSION == 'cortx-1.0' ?  "$os_version-1.0.0-1" : "$os_version-custom"}"
-        integration_dir = "${INTEGRATION_DIR_PATH == '/mnt/bigstorage/releases/cortx/github/integration-custom-ci/centos-7.9.2009/' ? "$release_dir/github/integration-custom-ci/$os_version/$release_tag" : "/mnt/bigstorage/releases/cortx/github/main/centos-7.9.2009/last_successful_prod"}"
     }
 
     options {
@@ -29,9 +27,9 @@ pipeline {
         string(name: 'CSM_AGENT_URL', defaultValue: 'https://github.com/Seagate/cortx-management.git', description: 'Repository URL for cortx-management build.')
         string(name: 'CSM_AGENT_BRANCH', defaultValue: 'stable', description: 'Branch for cortx-management build.')
         string(name: 'CUSTOM_CI_BUILD_ID', defaultValue: '0', description: 'Custom CI Build Number')
-        string(name: 'THIRD_PARTY_PYTHON_VERSION', defaultValue: 'cortx-2.0', description: 'Third Party Python Version to use', trim: true)
-        string(name: 'THIRD_PARTY_RPM_VERSION', defaultValue: 'cortx-2.0', description: 'Third Party RPM Version to use', trim: true)
-        string(name: 'INTEGRATION_DIR_PATH', defaultValue: '/mnt/bigstorage/releases/cortx/github/main/centos-7.9.2009/last_successful_prod/', description: 'Integration directory path', trim: true)
+        string(name: 'CORTX_UTILS_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for CORTX Utils', trim: true)
+        string(name: 'CORTX_UTILS_URL', defaultValue: 'https://github.com/Seagate/cortx-utils', description: 'CORTX Utils Repository URL', trim: true)
+        string(name: 'THIRD_PARTY_PYTHON_VERSION', defaultValue: 'custom', description: 'Third Party Python Version to use', trim: true)
     }    
 
 
@@ -60,7 +58,7 @@ pipeline {
                 sh label: 'Configure yum repository for cortx-py-utils', script: """
                     yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
 
-                    pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/python-packages-2.0.0-latest/ -r https://raw.githubusercontent.com/Seagate/cortx-utils/kubernetes/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/Seagate/cortx-utils/kubernetes/py-utils/python_requirements.ext.txt
+                    pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/$python_deps/ -r https://raw.githubusercontent.com/Seagate/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/Seagate/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.ext.txt
                 """
 
                 sh label: 'Install pyinstaller', script: """

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -85,7 +85,6 @@ pipeline {
         }
         
         stage ('Upload') {
-            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -57,34 +57,15 @@ pipeline {
             steps {
                 script { build_stage = env.STAGE_NAME }
 
-                sh label: 'Install cortx-prereq package', script: '''
-                                        cortx_iso_path=$( echo $integration_dir | sed  's/[/]mnt[/]bigstorage[/]//g' )
-                                        echo $cortx_iso_path
-                                        pip3 uninstall pip -y && yum reinstall python3-pip -y && ln -s /usr/bin/pip3 /usr/local/bin/pip3
-                                        yum install yum-utils -y
-                                        yum-config-manager --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/centos/$third_party_rpm_dir/
-                                        yum-config-manager --add-repo=http://cortx-storage.colo.seagate.com/$cortx_iso_path/cortx_iso/
-                                        yum-config-manager --save --setopt=cortx-storage*.gpgcheck=1 cortx-storage* && yum-config-manager --save --setopt=cortx-storage*.gpgcheck=0 cortx-storage*
-                                        yum clean all && rm -rf /var/cache/yum
-                                        cat <<EOF >>/etc/pip.conf
-[global]
-timeout: 60
-index-url: http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/$python_deps
-trusted-host: cortx-storage.colo.seagate.com
-EOF
-                                        yum install java-1.8.0-openjdk-headless -y && yum install cortx-prereq -y --nogpgcheck 
-                                        rm -rf  /etc/yum.repos.d/cortx-storage.colo.seagate.com_releases_cortx_* /etc/pip.conf
-                                '''
+                sh label: 'Configure yum repository for cortx-py-utils', script: """
+                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
 
-                sh label: 'Configure yum repositories', script: """
-                    yum-config-manager --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/integration-custom-ci/$os_version/$release_tag/cortx_iso/
-                    yum-config-manager --save --setopt=cortx-storage*.gpgcheck=1 cortx-storage* && yum-config-manager --save --setopt=cortx-storage*.gpgcheck=0 cortx-storage*
-                    yum clean all && rm -rf /var/cache/yum
+                    pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/python-packages-2.0.0-latest/ -r https://raw.githubusercontent.com/Seagate/cortx-utils/kubernetes/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/Seagate/cortx-utils/kubernetes/py-utils/python_requirements.ext.txt
                 """
 
                 sh label: 'Install pyinstaller', script: """
                         pip3.6 install  pyinstaller==3.5
-                    """
+                """
             }
         }    
         

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -106,6 +106,7 @@ EOF
         }
         
         stage ('Upload') {
+            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -25,7 +25,7 @@ pipeline {
     
     parameters {  
         string(name: 'CSM_AGENT_URL', defaultValue: 'https://github.com/Seagate/cortx-management.git', description: 'Repository URL for cortx-management build.')
-        string(name: 'CSM_AGENT_BRANCH', defaultValue: 'stable', description: 'Branch for cortx-management build.')
+        string(name: 'CSM_AGENT_BRANCH', defaultValue: 'main', description: 'Branch for cortx-management build.')
         string(name: 'CUSTOM_CI_BUILD_ID', defaultValue: '0', description: 'Custom CI Build Number')
         string(name: 'CORTX_UTILS_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for CORTX Utils', trim: true)
         string(name: 'CORTX_UTILS_URL', defaultValue: 'https://github.com/Seagate/cortx-utils', description: 'CORTX Utils Repository URL', trim: true)

--- a/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
@@ -153,7 +153,7 @@ pipeline {
                                         parameters: [
                                                         string(name: 'MOTR_URL', value: "${MOTR_URL}"),
                                                         string(name: 'MOTR_BRANCH', value: "${MOTR_BRANCH}"),
-														string(name: 'MOTR_BUILD_MODE', value: "${MOTR_BUILD_MODE}"),
+                                                        string(name: 'MOTR_BUILD_MODE', value: "${MOTR_BUILD_MODE}"),
                                                         string(name: 'S3_URL', value: "${S3_URL}"),
                                                         string(name: 'S3_BRANCH', value: "${S3_BRANCH}"),
                                                         string(name: 'HARE_URL', value: "${HARE_URL}"),
@@ -203,9 +203,9 @@ pipeline {
                                                     string(name: 'CSM_AGENT_URL', value: "${CSM_AGENT_URL}"),
                                                     string(name: 'CSM_AGENT_BRANCH', value: "${CSM_AGENT_BRANCH}"),
                                                     string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
-                                                    string(name: 'THIRD_PARTY_RPM_VERSION', value: "${THIRD_PARTY_RPM_VERSION}"),
-                                                    string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}"),
-                                                    string(name: 'INTEGRATION_DIR_PATH', value: "${integration_dir}")
+                                                    string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
+                                                    string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
+                                                    string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}")
                                               ]
                             } catch (err) {
                                 build_stage = env.STAGE_NAME

--- a/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy
@@ -49,22 +49,17 @@ pipeline {
             steps {
                 script { build_stage = env.STAGE_NAME }
 
-                sh label: 'Install cortx-prereq package', script: """
-                    pip3 uninstall pip -y && yum reinstall python3-pip -y && ln -s /usr/bin/pip3 /usr/local/bin/pip3
-                    sh ./cortx-re/scripts/third-party-rpm/install-cortx-prereq.sh
-                """
-                
-                sh label: 'Configure yum repositories', script: """
-                    yum-config-manager --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/$branch/$os_version/$release_tag/cortx_iso/
-                    yum-config-manager --save --setopt=cortx-storage*.gpgcheck=1 cortx-storage* && yum-config-manager --save --setopt=cortx-storage*.gpgcheck=0 cortx-storage*
-                    yum clean all && rm -rf /var/cache/yum
+                sh label: 'Configure yum repository for cortx-py-utils', script: """
+                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
+
+                    pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/python-packages-2.0.0-latest/ -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/python_requirements.ext.txt
                 """
 
                 sh label: 'Install pyinstaller', script: """
                         pip3.6 install  pyinstaller==3.5
                 """
             }
-        }        
+        }           
         
         stage('Build') {
             steps {
@@ -75,12 +70,13 @@ pipeline {
                     echo "Executing build script"
                     echo "Python:$(python --version)"
                     ./cicd/build.sh -v $version -b $BUILD_NUMBER -t -n ldr -l $WORKSPACE/seagate-ldr
-                popd    
-                '''    
+                popd
+                '''
             }
         }
         
         stage ('Upload') {
+            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''
@@ -96,6 +92,7 @@ pipeline {
         }
 
         stage ('Tag last_successful') {
+            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Tag last_successful', script: '''pushd $build_upload_dir/


### PR DESCRIPTION
# Problem Statement
- csm-agent build process installs cortx-prereq package installation. This installs non-required packages and also increases the build time. This change is to remove cortx-prereq package installation from the csm-agent build process.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - 
  custom-ci  - http://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/centos-7.9/job/cortx-all-image-custom-ci/1698/parameters/ 
Tested 3N deployment with image generated from above job i.e. cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-1698-custom-ci 
Post-merge check - http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/sv-csm-agent-build/13/console 
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide