### PR TITLE
EOS-25719  Add Motr, S3 and Hare debuginfo packages in cortx-all image.

### DIFF
--- a/docker/cortx-deploy/Dockerfile
+++ b/docker/cortx-deploy/Dockerfile
@@ -62,6 +62,7 @@ RUN yum install --nogpgcheck -y  $(sed 's/#.*//g' /opt/seagate/cortx/third-party
     && yum clean all && rm -rf /var/cache/yum
     
 RUN yum install --nogpgcheck -y  $(sed 's/#.*//g' /opt/seagate/cortx/cortx-componenet-rpms.txt) \
+    && yum install --nogpgcheck --downloadonly --downloaddir=/opt/seagate/cortx/debug-packages cortx-s3server-debuginfo cortx-hare-debuginfo cortx-motr-debuginfo \
     && yum clean all && rm -rf /var/cache/yum
     
 RUN rm -f /etc/machine-id && ln -s /etc/cortx/solution/node/id /etc/machine-id \

--- a/jenkins/internal-ci/centos-7.9.2009/branch/release.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/branch/release.groovy
@@ -72,7 +72,7 @@ pipeline {
                     cp -n -r $integration_dir/$release_tag/dev/* $integration_dir/$release_tag/prod/
 
                     pushd $integration_dir/$release_tag/prod
-                        rm -rf cortx-[hlp]*-debuginfo-*.rpm
+                        rm -rf cortx-[lp]*-debuginfo-*.rpm
                         rm -f cortx-s3iamcli*.rpm
                         rm -f cortx-s3-test*.rpm
                     popd


### PR DESCRIPTION
# Problem Statement
- Add Motr, S3 and Hare debuginfo packages in cortx-all image.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability. 
        Tested by manually generating image. 
```
[root@ssc-vm-rhev4-0707 cortx-deploy]# docker run --rm cortx-all:2.0.0-748 ls -l /opt/seagate/cortx/debug-packages/
total 23636
-rw-r--r-- 1 root root 14239168 Jan  4 09:59 cortx-motr-debuginfo-2.0.0-302_gitba397044_any.el7.x86_64.rpm
-rw-r--r-- 1 root root  9958632 Jan  4 09:59 cortx-s3server-debuginfo-2.0.0-307_gitc68a968c_el7.x86_64.rpm

```
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide