### PR TITLE
EOS-27281 - Custom build is failing in csm-agent build

### DIFF
--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -56,9 +56,11 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
 
                 sh label: 'Configure yum repository for cortx-py-utils', script: """
+                    CORTX_UTILS_REPO_OWNER=$(echo $CORTX_UTILS_URL | cut -d "/" -f4)
+                    
                     yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
 
-                    pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/$python_deps/ -r https://raw.githubusercontent.com/Seagate/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/Seagate/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.ext.txt
+                    pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/$python_deps/ -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.ext.txt
                 """
 
                 sh label: 'Install pyinstaller', script: """

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -55,13 +55,13 @@ pipeline {
             steps {
                 script { build_stage = env.STAGE_NAME }
 
-                sh label: 'Configure yum repository for cortx-py-utils', script: """
+                sh label: 'Configure yum repository for cortx-py-utils', script: '''
                     CORTX_UTILS_REPO_OWNER=$(echo $CORTX_UTILS_URL | cut -d "/" -f4)
-                    
+
                     yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
 
                     pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/$python_deps/ -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.ext.txt
-                """
+                '''
 
                 sh label: 'Install pyinstaller', script: """
                         pip3.6 install  pyinstaller==3.5


### PR DESCRIPTION
# Problem Statement
- Custom build is failing in csm-agent build for forked cortx-utils repo. The build was failing in installing the required python packages due to the hardcoded `Seagate` repo name. Modified logic to use provided cortx-utils forked repo 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested using - http://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/centos-7.9/job/cortx-all-image-custom-ci/1732/parameters/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide