### PR TITLE
EOS-26147 Fix solution-input pipeline failure

### DIFF
--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -134,6 +134,12 @@ function destroy-cluster(){
 }
 
 function io-test(){
+
+    if [ "$SOLUTION_CONFIG_TYPE" == manual ]; then
+        SOLUTION_CONFIG="$PWD/solution.yaml"
+        if [ -f '$SOLUTION_CONFIG' ]; then echo "file $SOLUTION_CONFIG not available..."; exit 1; fi
+    fi
+
     validation
     generate_rsa_key
     nodes_setup


### PR DESCRIPTION

# Problem Statement
-  setup-cortx-cluster-solution-input Jenkins pipeline is failing with below error - 
```
    00:08:33.286 + ./cortx-deploy.sh --io-test
    00:08:33.312  is not present
    00:08:33.389 Build step 'Execute shell' marked build as failure
    00:08:35.232 Archiving artifacts
```
# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested using  - http://eos-jenkins.colo.seagate.com/job/Cortx-Kubernetes/job/setup-cortx-cluster-solution-input/253/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide