### PR TITLE
EOS-26147 - Remove separate clean-up job, Print RPM build url location

### DIFF
--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -31,6 +31,7 @@ pipeline {
     // Please configure hosts,SNS and DIX parameter in Jenkins job configuration.
     stages {
         stage ("Define Variable") {
+            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 script {
@@ -55,6 +56,7 @@ pipeline {
         }
 
         stage ("Cluster Cleanup") {
+            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 script {
@@ -69,6 +71,7 @@ pipeline {
         }
 
         stage ("Deploy CORTX Cluster") {
+            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 script {
@@ -112,18 +115,19 @@ pipeline {
 
                    docker tag ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX} ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
 
-                   docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
+                   #docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
                    
-                   docker push ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
-                   docker push ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   #docker push ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   #docker push ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
                    
-                   docker rmi ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
-                   docker rmi ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   #docker rmi ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   #docker rmi ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
                 '''
            }
         }
 
         stage ("K8s QA Sanity") {
+            when { expression { false } }
             steps {
                 script {
                     catchError(stageResult: 'FAILURE') {

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -54,23 +54,7 @@ pipeline {
             }
         }
 
-        stage ("Cluster Cleanup") {
-            when { expression { false } }
-            steps {
-                script { build_stage = env.STAGE_NAME }
-                script {
-                    build job: '/Cortx-kubernetes/destroy-cortx-cluster', wait: true,
-                    parameters: [
-                        string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                        string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_REPO}"),
-                        text(name: 'hosts', value: "${hosts}")
-                    ]
-                }
-            }
-        }
-
         stage ("Deploy CORTX Cluster") {
-            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 script {

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -160,7 +160,7 @@ pipeline {
                 echo "${env.cortxCluster_status}"
                 echo "${env.qaSanity_status}"
                 if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "SUCCESS" ) {
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=Passed, SanityTest=Passed, Regression=Passed"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=Passed, SanityTest=Passed, Regression=Passed"
                     ICON = "accept.gif"
                     STATUS = "SUCCESS"
                     env.deployment_result = "SUCCESS"
@@ -168,7 +168,7 @@ pipeline {
                     currentBuild.result = "SUCCESS"
                 } else if ( "${env.cortxCluster_status}" == "FAILURE" || "${env.cortxCluster_status}" == "UNSTABLE" || "${env.cortxCluster_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=failed, SanityTest=skipped, Regression=skipped"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=failed, SanityTest=skipped, Regression=skipped"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "SKIPPED"
@@ -176,21 +176,21 @@ pipeline {
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" || "${env.qaSanity_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=Passed, SanityTest=failed, Regression=skipped"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=Passed, SanityTest=failed, Regression=skipped"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "FAILURE"
                     env.deployment_result = "SUCCESS"
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "UNSTABLE" ) {
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=Passed, SanityTest=passed, Regression=failed"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=Passed, SanityTest=passed, Regression=failed"
                     ICON = "unstable.gif"
                     STATUS = "UNSTABLE"
                     env.deployment_result = "SUCCESS"
                     env.sanity_result = "UNSTABLE"
                     currentBuild.result = "UNSTABLE"
                 } else {
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=unstable, SanityTest=unstable, Regression=unstable"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=unstable, SanityTest=unstable, Regression=unstable"
                     ICON = "unstable.gif"
                     STATUS = "UNSTABLE"
                     env.sanity_result = "UNSTABLE"

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -160,7 +160,7 @@ pipeline {
                 echo "${env.cortxCluster_status}"
                 echo "${env.qaSanity_status}"
                 if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "SUCCESS" ) {
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=Passed, SanityTest=Passed, Regression=Passed"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=Passed, Regression=Passed"
                     ICON = "accept.gif"
                     STATUS = "SUCCESS"
                     env.deployment_result = "SUCCESS"
@@ -168,7 +168,7 @@ pipeline {
                     currentBuild.result = "SUCCESS"
                 } else if ( "${env.cortxCluster_status}" == "FAILURE" || "${env.cortxCluster_status}" == "UNSTABLE" || "${env.cortxCluster_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=failed, SanityTest=skipped, Regression=skipped"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=failed, SanityTest=skipped, Regression=skipped"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "SKIPPED"
@@ -176,21 +176,21 @@ pipeline {
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" || "${env.qaSanity_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=Passed, SanityTest=failed, Regression=skipped"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=failed, Regression=skipped"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "FAILURE"
                     env.deployment_result = "SUCCESS"
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "UNSTABLE" ) {
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=Passed, SanityTest=passed, Regression=failed"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=passed, Regression=failed"
                     ICON = "unstable.gif"
                     STATUS = "UNSTABLE"
                     env.deployment_result = "SUCCESS"
                     env.sanity_result = "UNSTABLE"
                     currentBuild.result = "UNSTABLE"
                 } else {
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes} Node Deployment Deployment=unstable, SanityTest=unstable, Regression=unstable"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=unstable, SanityTest=unstable, Regression=unstable"
                     ICON = "unstable.gif"
                     STATUS = "UNSTABLE"
                     env.sanity_result = "UNSTABLE"

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -98,18 +98,19 @@ pipeline {
 
                    docker tag ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX} ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
 
-                   docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
+                   #docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
                    
-                   docker push ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
-                   docker push ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   #docker push ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   #docker push ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
                    
-                   docker rmi ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
-                   docker rmi ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   #docker rmi ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   #docker rmi ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
                 '''
            }
         }
 
         stage ("K8s QA Sanity") {
+            when { expression { false } }
             steps {
                 script {
                     catchError(stageResult: 'FAILURE') {

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -93,24 +93,23 @@ pipeline {
 
                    #Update VERSION details in RELEASE.INFO file
 
-                   #docker commit $(docker run -d ${CORTX_IMAGE} sed -i /VERSION/s/\\"2.0.0.*\\"/\\"${VERSION}-${BUILD_NUMBER}\\"/ /opt/seagate/cortx/RELEASE.INFO) ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   docker commit $(docker run -d ${CORTX_IMAGE} sed -i /VERSION/s/\\"2.0.0.*\\"/\\"${VERSION}-${BUILD_NUMBER}\\"/ /opt/seagate/cortx/RELEASE.INFO) ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
 
 
-                   #docker tag ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX} ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   docker tag ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX} ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
 
-                   #docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
+                   docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
                    
-                   #docker push ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
-                   #docker push ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   docker push ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   docker push ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
                    
-                   #docker rmi ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
-                   #docker rmi ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   docker rmi ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   docker rmi ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
                 '''
            }
         }
 
         stage ("K8s QA Sanity") {
-            when { expression { false } }
             steps {
                 script {
                     catchError(stageResult: 'FAILURE') {

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -98,19 +98,18 @@ pipeline {
 
                    docker tag ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX} ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
 
-                   #docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
+                   docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
                    
-                   #docker push ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
-                   #docker push ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   docker push ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   docker push ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
                    
-                   #docker rmi ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
-                   #docker rmi ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   docker rmi ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   docker rmi ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
                 '''
            }
         }
 
         stage ("K8s QA Sanity") {
-            when { expression { false } }
             steps {
                 script {
                     catchError(stageResult: 'FAILURE') {

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -89,7 +89,7 @@ pipeline {
                    docker pull $CORTX_IMAGE
 
                    echo "\n RPM Build URL used for Nightly Image"
-                   docker inspect cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-latest | jq -r '.[] | (.ContainerConfig.Cmd)' | grep 'BUILD_URL='
+                   docker inspect $CORTX_IMAGE | jq -r '.[] | (.ContainerConfig.Cmd)' | grep 'BUILD_URL='
 
                    #Update VERSION details in RELEASE.INFO file
 

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -102,6 +102,9 @@ pipeline {
                    echo \'y\' | docker image prune
                    docker pull $CORTX_IMAGE
 
+                   echo "\n RPM Build URL used for Nightly Image"
+                   docker inspect cortx-docker.colo.seagate.com/seagate/cortx-all:2.0.0-latest | jq -r '.[] | (.ContainerConfig.Cmd)' | grep 'BUILD_URL='
+
                    #Update VERSION details in RELEASE.INFO file
 
                    docker commit $(docker run -d ${CORTX_IMAGE} sed -i /VERSION/s/\\"2.0.0.*\\"/\\"${VERSION}-${BUILD_NUMBER}\\"/ /opt/seagate/cortx/RELEASE.INFO) ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}

--- a/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
+++ b/jenkins/automation/kubernetes/nightly-build-and-deploy.groovy
@@ -31,7 +31,6 @@ pipeline {
     // Please configure hosts,SNS and DIX parameter in Jenkins job configuration.
     stages {
         stage ("Define Variable") {
-            when { expression { false } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 script {
@@ -110,10 +109,10 @@ pipeline {
 
                    #Update VERSION details in RELEASE.INFO file
 
-                   docker commit $(docker run -d ${CORTX_IMAGE} sed -i /VERSION/s/\\"2.0.0.*\\"/\\"${VERSION}-${BUILD_NUMBER}\\"/ /opt/seagate/cortx/RELEASE.INFO) ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
+                   #docker commit $(docker run -d ${CORTX_IMAGE} sed -i /VERSION/s/\\"2.0.0.*\\"/\\"${VERSION}-${BUILD_NUMBER}\\"/ /opt/seagate/cortx/RELEASE.INFO) ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX}
 
 
-                   docker tag ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX} ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
+                   #docker tag ghcr.io/seagate/cortx-all:${VERSION}-${BUILD_NUMBER}-${GITHUB_TAG_SUFFIX} ghcr.io/seagate/cortx-all:${VERSION}-latest-${GITHUB_TAG_SUFFIX}
 
                    #docker login ghcr.io -u ${GITHUB_CRED_USR} -p ${GITHUB_CRED_PSW}
                    
@@ -161,7 +160,7 @@ pipeline {
                 echo "${env.cortxCluster_status}"
                 echo "${env.qaSanity_status}"
                 if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "SUCCESS" ) {
-                    MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=Passed, SanityTest=Passed, Regression=Passed"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=Passed, SanityTest=Passed, Regression=Passed"
                     ICON = "accept.gif"
                     STATUS = "SUCCESS"
                     env.deployment_result = "SUCCESS"
@@ -169,7 +168,7 @@ pipeline {
                     currentBuild.result = "SUCCESS"
                 } else if ( "${env.cortxCluster_status}" == "FAILURE" || "${env.cortxCluster_status}" == "UNSTABLE" || "${env.cortxCluster_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=failed, SanityTest=skipped, Regression=skipped"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=failed, SanityTest=skipped, Regression=skipped"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "SKIPPED"
@@ -177,21 +176,21 @@ pipeline {
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" || "${env.qaSanity_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=Passed, SanityTest=failed, Regression=skipped"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=Passed, SanityTest=failed, Regression=skipped"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "FAILURE"
                     env.deployment_result = "SUCCESS"
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "UNSTABLE" ) {
-                    MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=Passed, SanityTest=passed, Regression=failed"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=Passed, SanityTest=passed, Regression=failed"
                     ICON = "unstable.gif"
                     STATUS = "UNSTABLE"
                     env.deployment_result = "SUCCESS"
                     env.sanity_result = "UNSTABLE"
                     currentBuild.result = "UNSTABLE"
                 } else {
-                    MESSAGE = "K8s Build#${build_id} 3node Deployment Deployment=unstable, SanityTest=unstable, Regression=unstable"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}node Deployment Deployment=unstable, SanityTest=unstable, Regression=unstable"
                     ICON = "unstable.gif"
                     STATUS = "UNSTABLE"
                     env.sanity_result = "UNSTABLE"


### PR DESCRIPTION
# Problem Statement
-  Remove separate clean-up job. setup-cortx-cluster will ensure cleanup also.  
-  Print RPM build URL used to build the image. As the nightly latest build is used for image creation hence the number in the image name will not match with the build URL. Hence printing the build URL will help to locate rpms. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested using http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/nightly-ci-cd/282/console ( Please note status is failed as QA sanity is not executed)
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide