### PR TITLE
EOS-27483 : Tagging job not working

### DIFF
--- a/scripts/release_support/git-tag.sh
+++ b/scripts/release_support/git-tag.sh
@@ -62,16 +62,16 @@ declare -A COMPONENT_LIST=(
                 echo "Component2: "$component" , Repo:  "${COMPONENT_LIST[$component]}", Commit Hash: "$COMMIT_HASH""
                 pushd "$dir"
                 if [ "$GIT_TAG" != "" ]; then
-                        git tag -a $GIT_TAG $COMMIT_HASH -m $TAG_MESSAGE;
-                        git push origin $GIT_TAG;
+                        git tag -a "$GIT_TAG" "$COMMIT_HASH" -m "$TAG_MESSAGE";
+                        git push origin "$GIT_TAG";
                         echo "Component: $component , Tag: git tag -l $GIT_TAG is Tagged Successfully";
-                        git tag -l $GIT_TAG;
+                        git tag -l "$GIT_TAG";
                 else
                         echo "Tag is not successful. Please pass value to GIT_TAG";
                 fi
 
                 if [ "$DEBUG" = true ]; then
-                        git push origin --delete $GIT_TAG;
+                        git push origin --delete "$GIT_TAG";
                  else
                         echo "Run in Debug mode if Git tag needs to be deleted";
 

--- a/scripts/release_support/git-tag.sh
+++ b/scripts/release_support/git-tag.sh
@@ -80,4 +80,3 @@ declare -A COMPONENT_LIST=(
                 popd
         done
 
-


### PR DESCRIPTION
# Problem Statement
- Problem statement

# Design
-  Tagging working fine not we have change some command in git-tag shell script. Please find below shell script and jenkins job links.
     https://github.com/AbhijitPatil1992/cortx-re/blob/EOS-27483/scripts/release_support/git-tag.sh
     http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/ap_space/job/tagging/18/console

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide