### PR TITLE
EOS-27573: Added fix for busybox and changed master to primary.

### DIFF
--- a/solutions/kubernetes/cluster-functions.sh
+++ b/solutions/kubernetes/cluster-functions.sh
@@ -30,12 +30,12 @@ export ConfigException=101
 
 function usage(){
     cat << HEREDOC
-Usage : $0 [--prepare, --master]
+Usage : $0 [--prepare, --primary]
 where,
     --cleanup - Remove kubernetes and docker related packages on the nodes.
     --prepare - Install prerequisites on nodes for kubernetes setup.
     --status - Print cluster status.
-    --master - Initialize K8 master node. 
+    --primary - Initialize K8 primary node. 
     --join-worker-nodes Join worker nodes to kubernetes cluster.
 HEREDOC
 }
@@ -240,8 +240,8 @@ function install_prerequisites(){
 
 }
 
-function setup_master_node(){
-    local UNTAINT_MASTER=$1
+function setup_primary_node(){
+    local UNTAINT_PRIMARY=$1
     try
     (
         #cleanup
@@ -257,9 +257,9 @@ function setup_master_node(){
         mkdir -p $HOME/.kube
         cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
         chown $(id -u):$(id -g) $HOME/.kube/config
-        # untaint master node
-        if [ "$UNTAINT_MASTER" == "true" ]; then
-            echo "--------------------------[ Allow POD creation on master node ]--------------------------"
+        # untaint primary node
+        if [ "$UNTAINT_PRIMARY" == "true" ]; then
+            echo "--------------------------[ Allow POD creation on primary node ]--------------------------"
             kubectl taint nodes $(hostname) node-role.kubernetes.io/master- || throw $Exception
         fi    
 
@@ -321,8 +321,8 @@ case $ACTION in
     --status) 
         print_cluster_status
     ;;
-    --master)
-        setup_master_node "$2"
+    --primary)
+        setup_primary_node "$2"
     ;;
     --join-worker-nodes)
         join_worker_nodes "$@"

--- a/solutions/kubernetes/cluster-functions.sh
+++ b/solutions/kubernetes/cluster-functions.sh
@@ -273,9 +273,6 @@ function setup_master_node(){
         # Setup IP_AUTODETECTION_METHOD for determining calico network.
         # sed -i '/# Auto-detect the BGP IP address./i \            - name: IP_AUTODETECTION_METHOD\n              value: "interface=eth-0"' calico-$CALICO_PLUGIN_VERSION.yaml
         kubectl apply -f calico-$CALICO_PLUGIN_VERSION.yaml || throw $Exception
-        # Setup storage-class
-        kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml || throw $Exception
-        kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}' || throw $ConfigException
 
         # Install helm
         curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 || throw $Exception

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -195,14 +195,6 @@ function execute_deploy_script(){
     popd
 }
 
-#Adding quick fix for all nodes to pull busybox images from ghcr.io/seagate.
-#On fresh system when CORTX deployment is done docker pulls busybox image from docker hub by default even though ghcr.io/seagate location is mentioned in code. 
-#This is to be removed after issue is resolved.
-function download_images(){
-    echo "---------------------------------------[ Download busybox image from ghcr.io/seagate/busybox ]--------------------------------------"
-    docker pull ghcr.io/seagate/busybox:latest
-}
-
 #On worker
 #format and mount system drive
 
@@ -267,7 +259,6 @@ echo "---------------------------------------[ Setting up Master Node $HOSTNAME 
     #Third-party images are downloaded from GitHub container registry. 
     download_deploy_script
     install_yq
-    #download_images
     
     if [ "$(kubectl get  nodes $HOSTNAME  -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints}" | grep -o NoSchedule)" == "" ]; then
         execute_prereq
@@ -288,7 +279,6 @@ echo "---------------------------------------[ Setting up Worker Node on $HOSTNA
     #Third-party images are downloaded from GitHub container registry.
     download_deploy_script
     execute_prereq
-    #download_images
 }
 
 function destroy(){

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -267,7 +267,7 @@ echo "---------------------------------------[ Setting up Master Node $HOSTNAME 
     #Third-party images are downloaded from GitHub container registry. 
     download_deploy_script
     install_yq
-    download_images
+    #download_images
     
     if [ "$(kubectl get  nodes $HOSTNAME  -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints}" | grep -o NoSchedule)" == "" ]; then
         execute_prereq
@@ -288,7 +288,7 @@ echo "---------------------------------------[ Setting up Worker Node on $HOSTNA
     #Third-party images are downloaded from GitHub container registry.
     download_deploy_script
     execute_prereq
-    download_images
+    #download_images
 }
 
 function destroy(){

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -27,7 +27,7 @@ YQ_VERSION=v4.13.3
 YQ_BINARY=yq_linux_386
 SOLUTION_CONFIG="/var/tmp/solution.yaml"
 
-#On master
+#On primary
 #download CORTX k8 deployment scripts
 
 function download_deploy_script(){
@@ -235,10 +235,10 @@ function execute_prereq(){
 
 function usage(){
     cat << HEREDOC
-Usage : $0 [--setup-worker, --setup-master, --third-party, --cortx-cluster, --destroy, --status]
+Usage : $0 [--setup-worker, --setup-primary, --third-party, --cortx-cluster, --destroy, --status]
 where,
     --setup-worker - Setup k8 worker node for CORTX deployment
-    --setup-master - Setup k8 master node for CORTX deployment
+    --setup-primary - Setup k8 primary node for CORTX deployment
     --third-party - Deploy third-party components
     --cortx-cluster - Deploy Third-Party and CORTX components
     --destroy - Destroy CORTX Cluster
@@ -254,8 +254,8 @@ if [ -z "$ACTION" ]; then
     exit 1
 fi
 
-function setup_master_node(){
-echo "---------------------------------------[ Setting up Master Node $HOSTNAME ]--------------------------------------"
+function setup_primary_node(){
+echo "---------------------------------------[ Setting up Primary Node $HOSTNAME ]--------------------------------------"
     #Third-party images are downloaded from GitHub container registry. 
     download_deploy_script
     install_yq
@@ -400,8 +400,8 @@ case $ACTION in
     --generate-logs)
         logs_generation
     ;;
-    --setup-master)
-        setup_master_node 
+    --setup-primary)
+        setup_primary_node 
     ;;
     *)
         echo "ERROR : Please provide valid option"

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -195,6 +195,14 @@ function execute_deploy_script(){
     popd
 }
 
+#Adding quick fix for all nodes to pull busybox images from ghcr.io/seagate.
+#On fresh system when CORTX deployment is done docker pulls busybox image from docker hub by default even though ghcr.io/seagate location is mentioned in code. 
+#This is to be removed after issue is resolved.
+function download_images(){
+    echo "---------------------------------------[ Download busybox image from ghcr.io/seagate/busybox ]--------------------------------------"
+    docker pull ghcr.io/seagate/busybox:latest
+}
+
 #On worker
 #format and mount system drive
 
@@ -256,9 +264,10 @@ fi
 
 function setup_master_node(){
 echo "---------------------------------------[ Setting up Master Node $HOSTNAME ]--------------------------------------"
+    #Third-party images are downloaded from GitHub container registry. 
     download_deploy_script
-    #Third-party images are downloaed from GitHub container regsitry. 
     install_yq
+    download_images
     
     if [ "$(kubectl get  nodes $HOSTNAME  -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints}" | grep -o NoSchedule)" == "" ]; then
         execute_prereq
@@ -276,9 +285,10 @@ echo "---------------------------------------[ Setting up Master Node $HOSTNAME 
 
 function setup_worker_node(){
 echo "---------------------------------------[ Setting up Worker Node on $HOSTNAME ]--------------------------------------"
-    #Third-party images are downloaed from GitHub container regsitry.
+    #Third-party images are downloaded from GitHub container registry.
     download_deploy_script
     execute_prereq
+    download_images
 }
 
 function destroy(){

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -70,7 +70,7 @@ function setup_cluster {
 
     TARGET=$1
     ALL_NODES=$(cat "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
-    MASTER_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
+    PRIMARY_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
 
     for node in $ALL_NODES
         do
@@ -79,58 +79,58 @@ function setup_cluster {
      
     if [ "$(wc -l < $HOST_FILE)" == "1" ]; then
        echo "---------------------------------------[ Single node deployment ]----------------------------------"
-       echo "NODE:" $MASTER_NODE
-       ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" "export SOLUTION_CONFIG_TYPE=$SOLUTION_CONFIG_TYPE && export CORTX_IMAGE=$CORTX_IMAGE && export CORTX_SCRIPTS_REPO=$CORTX_SCRIPTS_REPO && export CORTX_SCRIPTS_BRANCH=$CORTX_SCRIPTS_BRANCH && export SNS_CONFIG=$SNS_CONFIG && export DIX_CONFIG=$DIX_CONFIG && /var/tmp/cortx-deploy-functions.sh --setup-master"
+       echo "NODE:" $PRIMARY_NODE
+       ssh -o 'StrictHostKeyChecking=no' "$PRIMARY_NODE" "export SOLUTION_CONFIG_TYPE=$SOLUTION_CONFIG_TYPE && export CORTX_IMAGE=$CORTX_IMAGE && export CORTX_SCRIPTS_REPO=$CORTX_SCRIPTS_REPO && export CORTX_SCRIPTS_BRANCH=$CORTX_SCRIPTS_BRANCH && export SNS_CONFIG=$SNS_CONFIG && export DIX_CONFIG=$DIX_CONFIG && /var/tmp/cortx-deploy-functions.sh --setup-primary"
     else
-       WORKER_NODES=$(cat "$HOST_FILE" | grep -v "$MASTER_NODE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
+       WORKER_NODES=$(cat "$HOST_FILE" | grep -v "$PRIMARY_NODE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
     fi
 
-    # Setup master node and all worker nodes in parallel in case of multinode cluster.
+    # Setup primary node and all worker nodes in parallel in case of multinode cluster.
     if [ "$(wc -l < $HOST_FILE)" -ne "1" ]; then
        NODES=$(wc -l < $HOST_FILE)
-       TAINTED_NODES=$(ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" bash << EOF
+       TAINTED_NODES=$(ssh -o 'StrictHostKeyChecking=no' "$PRIMARY_NODE" bash << EOF
 kubectl get nodes -o jsonpath="{range .items[*]}{.metadata.name} {.spec.taints[?(@.effect=='NoSchedule')].effect}{\"\n\"}{end}" | grep  NoSchedule | wc -l
 EOF
 )
        NODES="$((NODES-TAINTED_NODES))"
        echo "---------------------------------------[ $NODES node deployment ]----------------------------------"
-       echo "MASTER NODE:" $MASTER_NODE
+       echo "PRIMARY NODE:" $PRIMARYPRIMARY_NODE
        echo "WORKER NODE:" $WORKER_NODES
        # pdsh hosts to run parallel implementations.
        echo $WORKER_NODES > /var/tmp/pdsh-hosts
        pdsh_worker_exec /var/tmp/pdsh-hosts
 
-       for master_node in $MASTER_NODE
+       for primary_node in $PRIMARY_NODE
            do
-               ssh -o 'StrictHostKeyChecking=no' "$master_node" "export SOLUTION_CONFIG_TYPE=$SOLUTION_CONFIG_TYPE && export CORTX_IMAGE=$CORTX_IMAGE && export CORTX_SCRIPTS_REPO=$CORTX_SCRIPTS_REPO && export CORTX_SCRIPTS_BRANCH=$CORTX_SCRIPTS_BRANCH && export SNS_CONFIG=$SNS_CONFIG && export DIX_CONFIG=$DIX_CONFIG && /var/tmp/cortx-deploy-functions.sh --setup-master"
+               ssh -o 'StrictHostKeyChecking=no' "$primary_node" "export SOLUTION_CONFIG_TYPE=$SOLUTION_CONFIG_TYPE && export CORTX_IMAGE=$CORTX_IMAGE && export CORTX_SCRIPTS_REPO=$CORTX_SCRIPTS_REPO && export CORTX_SCRIPTS_BRANCH=$CORTX_SCRIPTS_BRANCH && export SNS_CONFIG=$SNS_CONFIG && export DIX_CONFIG=$DIX_CONFIG && /var/tmp/cortx-deploy-functions.sh --setup-primary"
            done
     fi
 
-    for master_node in $MASTER_NODE
+    for primary_node in $PRIMARY_NODE
         do
-        ssh -o 'StrictHostKeyChecking=no' "$master_node" "/var/tmp/cortx-deploy-functions.sh --$TARGET"
+        ssh -o 'StrictHostKeyChecking=no' "$primary_node" "/var/tmp/cortx-deploy-functions.sh --$TARGET"
         echo "---------------------------------------[ Print Cluster Status ]----------------------------------------------"
         rm -rf /var/tmp/cortx-cluster-status.txt
-        ssh -o 'StrictHostKeyChecking=no' "$master_node" '/var/tmp/cortx-deploy-functions.sh --status' | tee /var/tmp/cortx-cluster-status.txt
+        ssh -o 'StrictHostKeyChecking=no' "$primary_node" '/var/tmp/cortx-deploy-functions.sh --status' | tee /var/tmp/cortx-cluster-status.txt
         done
 }
 
 function support_bundle(){
-    MASTER_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
+    PRIMARY_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
     echo -e "\n---------------------------------------[ Collect CORTX Support Bundle Logs ]----------------------------------------------"
-    ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" '/var/tmp/cortx-deploy-functions.sh --generate-logs'
+    ssh -o 'StrictHostKeyChecking=no' "$PRIMARY_NODE" '/var/tmp/cortx-deploy-functions.sh --generate-logs'
 }
 
 function destroy-cluster(){
     validation
     generate_rsa_key
     nodes_setup
-	MASTER_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
-	echo "---------------------------------------[ Destroying cluster from $MASTER_NODE ]----------------------------------------------"
-        scp -q cortx-deploy-functions.sh functions.sh "$MASTER_NODE":/var/tmp/
-        ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" "/var/tmp/cortx-deploy-functions.sh --destroy"
+	PRIMARY_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
+	echo "---------------------------------------[ Destroying cluster from $PRIMARY_NODE ]----------------------------------------------"
+        scp -q cortx-deploy-functions.sh functions.sh "$PRIMARY_NODE":/var/tmp/
+        ssh -o 'StrictHostKeyChecking=no' "$PRIMARY_NODE" "/var/tmp/cortx-deploy-functions.sh --destroy"
         echo "--------------------------------[ Print Kubernetes Cluster Status after Cleanup]----------------------------------------------"
-        ssh -o 'StrictHostKeyChecking=no' "$MASTER_NODE" 'kubectl get pods -o wide' | tee /var/tmp/cortx-cluster-status.txt	
+        ssh -o 'StrictHostKeyChecking=no' "$PRIMARY_NODE" 'kubectl get pods -o wide' | tee /var/tmp/cortx-cluster-status.txt	
 }
 
 function io-test(){
@@ -143,13 +143,13 @@ function io-test(){
     validation
     generate_rsa_key
     nodes_setup
-    MASTER_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
-    for master_node in $MASTER_NODE
+    PRIMARY_NODE=$(head -1 "$HOST_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
+    for primary_node in $PRIMARY_NODE
         do
         # IO test
         add_separator Setting up IO testing
-        scp -q io-testing.sh s3-client-setup.sh "$master_node":/var/tmp/
-        ssh -o 'StrictHostKeyChecking=no' "$master_node" "export DEPLOYMENT_TYPE=$DEPLOYMENT_TYPE && /var/tmp/cortx-deploy-functions.sh --io-test"
+        scp -q io-testing.sh s3-client-setup.sh "$primary_node":/var/tmp/
+        ssh -o 'StrictHostKeyChecking=no' "$primary_node" "export DEPLOYMENT_TYPE=$DEPLOYMENT_TYPE && /var/tmp/cortx-deploy-functions.sh --io-test"
         done
 }
 

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -94,7 +94,7 @@ EOF
 )
        NODES="$((NODES-TAINTED_NODES))"
        echo "---------------------------------------[ $NODES node deployment ]----------------------------------"
-       echo "PRIMARY NODE:" $PRIMARYPRIMARY_NODE
+       echo "PRIMARY NODE:" $PRIMARY_NODE
        echo "WORKER NODE:" $WORKER_NODES
        # pdsh hosts to run parallel implementations.
        echo $WORKER_NODES > /var/tmp/pdsh-hosts

--- a/solutions/kubernetes/prvsnr-framework-functions.sh
+++ b/solutions/kubernetes/prvsnr-framework-functions.sh
@@ -25,9 +25,9 @@ PRVSNR_SCRIPTS="test/deploy/kubernetes"
 
 function usage(){
     cat << HEREDOC
-Usage : $0 [--setup-master, --setup-worker, --upgrade, --destroy]
+Usage : $0 [--setup-primary, --setup-worker, --upgrade, --destroy]
 where,
-    --setup-master - Setup master node for CORTX deployment
+    --setup-primary - Setup primary node for CORTX deployment
     --setup-worker - Setup worker node for CORTX deployment
     --upgrade - Upgrade CORTX cluster
     --destroy  - Destroy CORTX cluster
@@ -56,7 +56,7 @@ function setup_worker_node(){
 
 }
 
-function setup_master_node(){
+function setup_primary_node(){
     download_prvsnr_script
     pushd $SCRIPT_LOCATION/$PRVSNR_SCRIPTS
         echo "---------------------------------------[ Prerequisite for Deployment ]----------------------------------"
@@ -93,8 +93,8 @@ if [ -z "$ACTION" ]; then
 fi
 
 case $ACTION in
-    --setup-master)
-        setup_master_node        
+    --setup-primary)
+        setup_primary_node        
     ;;
     --setup-worker)
         setup_worker_node        


### PR DESCRIPTION
Signed-off-by: Nitish Singh <nitish.singh@seagate.com>

# Problem Statement
- By default during CORTX deployment on fresh VMs busybox image is being downloaded from docker hub even though passing the ghcr.io repo, which runs into errors due to rate limit thus halting deployement.

# Design
-  Added fix for busybox. local-path-provisioner is now deployed with CORTX deployment only.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Fresh VMs single node: http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_deploy_k8s_cortx_cluster/60/
- Fresh VMs 3 node: http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_deploy_k8s_cortx_cluster/61/

After master change
- deploy-k8s-cortx-cluster: http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_deploy_k8s_cortx_cluster/62/console 
- test-cortx-setup: http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_cortx_setup/207
- prvsnr deployment: http://eos-jenkins.colo.seagate.com/job/Provisioner/job/prvsnr_framework_deployment/18/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide