### PR TITLE
Fix - csm-agent groovy script is hardcoded for pyutils build

### DIFF
--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -61,6 +61,7 @@ pipeline {
                     yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/$branch/$os_version/$release_tag/cortx_iso/
 
                     pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/$python_deps/ -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.ext.txt
+                    yum install cortx-py-utils -y --nogpgcheck
                 '''
 
                 sh label: 'Install pyinstaller', script: """

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -8,7 +8,7 @@ pipeline {
     
     environment { 
         component = "csm-agent"
-        branch = "custom-ci" 
+        branch = "integration-custom-ci" 
         os_version = "centos-7.9.2009"
         release_dir = "/mnt/bigstorage/releases/cortx"
         release_tag = "custom-build-$CUSTOM_CI_BUILD_ID"

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -58,7 +58,7 @@ pipeline {
                 sh label: 'Configure yum repository for cortx-py-utils', script: '''
                     CORTX_UTILS_REPO_OWNER=$(echo $CORTX_UTILS_URL | cut -d "/" -f4)
 
-                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
+                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/$branch/$os_version/$release_tag/cortx_iso/
 
                     pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/$python_deps/ -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.ext.txt
                 '''

--- a/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/csm-agent.groovy
@@ -58,7 +58,7 @@ pipeline {
                 sh label: 'Configure yum repository for cortx-py-utils', script: '''
                     CORTX_UTILS_REPO_OWNER=$(echo $CORTX_UTILS_URL | cut -d "/" -f4)
 
-                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/$branch/$os_version/$release_tag/cortx_iso/
+                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
 
                     pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/$python_deps/ -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/$CORTX_UTILS_REPO_OWNER/cortx-utils/$CORTX_UTILS_BRANCH/py-utils/python_requirements.ext.txt
                 '''

--- a/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
+++ b/jenkins/custom-ci/centos-7.9.2009/custom-ci.groovy
@@ -204,7 +204,7 @@ pipeline {
                         script { build_stage = env.STAGE_NAME }
                         script {
                             try {
-                                def csm_agent_build = build job: '/GitHub-custom-ci-builds/centos-7.9/custom-csm-agent-build', wait: true,
+                                def csm_agent_build = build job: '/Release_Engineering/re-workspace/sg_workspace/custom-csm-agent-build', wait: true,
                                               parameters: [
                                                     string(name: 'CSM_AGENT_URL', value: "${CSM_AGENT_URL}"),
                                                     string(name: 'CSM_AGENT_BRANCH', value: "${CSM_AGENT_BRANCH}"),

--- a/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy
@@ -50,7 +50,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
 
                 sh label: 'Configure yum repository for cortx-py-utils', script: """
-                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
+                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/$branch/$os_version/$release_tag/cortx_iso/
 
                     pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/python-packages-2.0.0-latest/ -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/python_requirements.ext.txt
                 """


### PR DESCRIPTION
Signed-off-by: Swanand S Gadre <swanand.s.gadre@seagate.com>

# Problem Statement
- Problem statement

csm-agent groovy script is hardcoded for pyutils build
https://jts.seagate.com/browse/EOS-28500

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

cortx-re repository has a hard-coded path for picking up py-utils build

cortx-re/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy

This needs to be fixed, as otherwise custom-ci builds refer to the hardcoded path and doesn't accommodate changes as per 
custom build.

As a fix, build No, release_tag and os_versions are used to build path

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM



# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

Not applicable