### PR TITLE
EOS-28480: commands needed by motr support bundle, but not present in…

### DIFF
--- a/docker/cortx-deploy/third-party-rpms.txt
+++ b/docker/cortx-deploy/third-party-rpms.txt
@@ -21,6 +21,5 @@ hiredis-0.12.1 #cortx-s3srever
 sshpass
 sudo
 file #cortx-motr
-less #cortx-motr
 symas-openldap-clients #cortx-s3server
 which #cortx-motr

--- a/docker/cortx-deploy/third-party-rpms.txt
+++ b/docker/cortx-deploy/third-party-rpms.txt
@@ -20,5 +20,7 @@ python36-pika-0.10.0 #cortx-s3srever
 hiredis-0.12.1 #cortx-s3srever
 sshpass
 sudo
+file
+less
 symas-openldap-clients #cortx-s3server
 which #cortx-motr

--- a/docker/cortx-deploy/third-party-rpms.txt
+++ b/docker/cortx-deploy/third-party-rpms.txt
@@ -20,7 +20,7 @@ python36-pika-0.10.0 #cortx-s3srever
 hiredis-0.12.1 #cortx-s3srever
 sshpass
 sudo
-file
-less
+file #cortx-motr
+less #cortx-motr
 symas-openldap-clients #cortx-s3server
 which #cortx-motr


### PR DESCRIPTION
### Specification of requested package

Details | Values
------ | ------
Package Name  |  file-5.11-37.el7.x86_64
Version | 5.11
license | BSD
Source  | 

### Please add below details about package

* [ ] Purpose of using new SW ?
motr support bundle 
* [ ] Location of the source code of new opensource SW ?
 http://buildlogs-seed.centos.org/c7.2009.00.x86_64/file/20200930160602/5.11-37.el7.x86_64/
* [ ] Did you evaluate existing SW and confirm they do not serve the purpose ? If yes, include the comparison. If no, why ?
No any command which can be used instead of file 
* [ ] Who is building it or how it gets built ? If yes, Which component/rpm will it be included ? i.e. name of the rpm which includes SW.
file-5.11-37.el7.x86_64
* [ ] Download location of opensource software package ?
http://buildlogs-seed.centos.org/c7.2009.00.x86_64/file/20200930160602/5.11-37.el7.x86_64/
* [ ] Who will be supporting this package ?
* [ ] Is there a configuration required for this? Who will be configuring it ?
* [ ] Which component is responsible for deploying on nodes ?
* [ ] What is the licensing policy ? Is it approved by legal ? 