### PR TITLE
CORTX-28927 - upgrade package numpy from 1.19.XX to 1.19.5

### DIFF
--- a/docker/cortx-deploy/python_requirements.ext.txt
+++ b/docker/cortx-deploy/python_requirements.ext.txt
@@ -3,6 +3,6 @@
 # depdendencies of cryptography 
 cffi==1.14.5
 # depdendencies of python==3.6
-numpy==1.19.2
+numpy==1.19.5
 # dependency of cifi
 pycparser==2.20

--- a/scripts/third-party-rpm/python_requirements.ext.txt
+++ b/scripts/third-party-rpm/python_requirements.ext.txt
@@ -3,6 +3,6 @@
 # depdendencies of cryptography 
 cffi==1.14.5
 # depdendencies of python==3.6
-numpy==1.19.2
+numpy==1.19.5
 # dependency of cifi
 pycparser==2.20


### PR DESCRIPTION

### Specification of requested package

Details | Values
------ | ------
Package Name  | numpy
Version | 1.19.5
license | BSD
Source  | https://pypi.org/project/numpy/1.19.5/


### Please add below details about package

* [X] Purpose of using new SW ? 
Minor upgrade from 1.19.2 to 1.19.5 (for compliance)
* [X] Location of the source code of new opensource SW ? - 
https://github.com/numpy/numpy
* [X] Did you evaluate existing SW and confirm they do not serve the purpose ? If yes, include the comparison. If no, why ?  This upgrade is planned for compliance and not necessarily to pick up any specific fix. Basic build and testing is complete with newer version and results are uploaded in https://jts.seagate.com/browse/CORTX-28927
* [X] Who is building it or how it gets built ? If yes, Which component/rpm will it be included ? i.e. name of the rpm which includes SW. -
 whl file is picked up from https://pypi.org/project/numpy/1.19.5/ - 
numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl
* [X] Download location of opensource software package ? 
https://pypi.org/project/numpy/1.19.5/#files
* [X] Who will be supporting this package ? 
opensource community
* [X] Is there a configuration required for this? Who will be configuring it ?
No configuration required.
* [X] Which component is responsible for deploying on nodes ?
cortx-re
* [X] What is the licensing policy ? Is it approved by legal ? 
This is minor version upgrade
version 1.19.2 is in use for long time.
As per whitesource tool, it has BSD license.
Legal team hasn't reported any non compliance




