### PR TITLE
CORTX-28592 - Exclude calico plugin images from prune

### DIFF
--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -392,7 +392,7 @@ function logs_generation(){
 
 function cleanup(){
     echo -e "\n-----------[ Clean up untagged/unused images and stopped containers... ]--------------------"
-    docker system prune -a -f
+    docker system prune -a -f --filter "label!=vendor=Project Calico"
 }
 
 case $ACTION in


### PR DESCRIPTION
# Problem Statement
-  `docker system prune -a -f` is cleaning up calico plugin images from cluster.   calico-node pods goes to `ImagePullBackOff` state. 

```
[root@ssc-vm-rhev4-1831 ~]# kubectl get pods -A
NAMESPACE            NAME                                                         READY   STATUS                  RESTARTS   AGE
default              consul-client-7lfr7                                          1/1     Running                 0          5m52s
default              consul-client-gtnq7                                          1/1     Running                 0          5m52s
default              consul-client-rmvd8                                          1/1     Running                 0          5m52s
default              consul-server-0                                              1/1     Running                 0          4m17s
default              consul-server-1                                              1/1     Running                 0          5m15s
default              consul-server-2                                              1/1     Running                 0          5m51s
default              cortx-control-fc8bf4587-hmbhr                                4/4     Running                 0          68s
default              cortx-data-ssc-vm-rhev4-1831-54fb67b946-zdml7                0/4     Init:0/2                0          12s
default              cortx-data-ssc-vm-rhev4-1838-5b8fcffdb7-s865c                0/4     Init:0/2                0          12s
default              cortx-data-ssc-vm-rhev4-1839-5b57dd9d5b-gt84c                0/4     Init:0/2                0          11s
default              kafka-0                                                      1/1     Running                 0          3m14s
default              kafka-1                                                      1/1     Running                 0          3m14s
default              kafka-2                                                      1/1     Running                 0          3m14s
default              openldap-0                                                   1/1     Running                 0          5m50s
default              openldap-1                                                   1/1     Running                 0          5m33s
default              openldap-2                                                   1/1     Running                 0          5m20s
default              zookeeper-0                                                  1/1     Running                 0          4m44s
default              zookeeper-1                                                  1/1     Running                 0          4m44s
default              zookeeper-2                                                  1/1     Running                 0          4m44s
kube-system          calico-kube-controllers-558995777d-phln4                     1/1     Running                 3          60d
kube-system          calico-node-2xvq6                                            0/1     Init:ImagePullBackOff   0          60d
kube-system          calico-node-87xfc                                            0/1     Init:ImagePullBackOff   0          60d
kube-system          calico-node-z4gts                                            0/1     Init:ImagePullBackOff   0          60d
kube-system          coredns-f9fd979d6-hm6v6                                      1/1     Running                 2          60d
kube-system          coredns-f9fd979d6-whkbk                                      1/1     Running                 2          60d
kube-system          etcd-ssc-vm-rhev4-1831.colo.seagate.com                      1/1     Running                 2          60d
kube-system          kube-apiserver-ssc-vm-rhev4-1831.colo.seagate.com            1/1     Running                 2          60d
kube-system          kube-controller-manager-ssc-vm-rhev4-1831.colo.seagate.com   1/1     Running                 7          60d
kube-system          kube-proxy-czcrj                                             1/1     Running                 2          60d
kube-system          kube-proxy-gfvvb                                             1/1     Running                 1          60d
kube-system          kube-proxy-h49dp                                             1/1     Running                 1          60d
kube-system          kube-scheduler-ssc-vm-rhev4-1831.colo.seagate.com            1/1     Running                 7          60d
local-path-storage   local-path-provisioner-58d4d88cb4-ql9gz                      1/1     Running                 0          5m53s
[root@ssc-vm-rhev4-1831 ~]#
```

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability - Tested using - http://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/setup-cortx-cluster/141/console
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide