### PR TITLE
CORTX-28911 - Set yum repo for cortx-py-utils packages based on branch and os variable. 

### DIFF
--- a/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy
@@ -50,7 +50,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
 
                 sh label: 'Configure yum repository for cortx-py-utils', script: """
-                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/kubernetes/centos-7.9.2009/last_successful_prod/cortx_iso/
+                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/$branch/centos-7.9.2009/last_successful_prod/cortx_iso/
 
                     pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/python-packages-2.0.0-latest/ -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/python_requirements.ext.txt
                 """

--- a/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy
+++ b/jenkins/internal-ci/centos-7.9.2009/branch/csm-agent.groovy
@@ -17,6 +17,7 @@ pipeline {
         release_dir = "/mnt/bigstorage/releases/cortx"
         release_tag = "last_successful_prod"
         build_upload_dir = "$release_dir/components/github/$branch/$os_version/$env/$component"
+        // Please configure branch and os_version in Jenkins configuration.
     }
 
     options {
@@ -50,7 +51,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
 
                 sh label: 'Configure yum repository for cortx-py-utils', script: """
-                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/$branch/centos-7.9.2009/last_successful_prod/cortx_iso/
+                    yum-config-manager --nogpgcheck --add-repo=http://cortx-storage.colo.seagate.com/releases/cortx/github/$branch/$os_version/last_successful_prod/cortx_iso/
 
                     pip3 install --no-cache-dir --trusted-host cortx-storage.colo.seagate.com -i http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/python-deps/python-packages-2.0.0-latest/ -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/python_requirements.txt -r https://raw.githubusercontent.com/Seagate/cortx-utils/$branch/py-utils/python_requirements.ext.txt
                 """


### PR DESCRIPTION
# Problem Statement
-  csm-agent Jenkins pipeline was failing as it's installing cortx-py-utils from the old location. Modified code to install it from the branch and os provided to Jenkins pipeline.  e.g.  https://eos-jenkins.colo.seagate.com/job/Cortx-Kubernetes/job/post-merge/view/Main_Dashboard/job/csm-agent/319/

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM - https://eos-jenkins.colo.seagate.com/job/Cortx-Kubernetes/job/post-merge/view/Main_Dashboard/job/csm-agent/320/ 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide