### PR TITLE
CORTX-29301 Set default AWS region for IO Testing

### DIFF
--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -12,8 +12,8 @@ pipeline {
         disableConcurrentBuilds()
     }
     environment {
-        CORTX_RE_BRANCH = "rocky-linux-custom-ci"
-        CORTX_RE_REPO = "https://github.com/shailesh-vaidya/cortx-re"
+        CORTX_RE_BRANCH = "main"
+        CORTX_RE_REPO = "https://github.com/Seagate/cortx-re"
         DOCKER_IMAGE_LOCATION = "https://github.com/Seagate/cortx-re/pkgs/container/cortx-all"
         LOCAL_REG_CRED = credentials('local-registry-access')
         GITHUB_CRED = credentials('shailesh-github')

--- a/solutions/kubernetes/io-testing.sh
+++ b/solutions/kubernetes/io-testing.sh
@@ -46,6 +46,9 @@ check_status "Failed to set awscli s3 plugin endpoint."
 echo -e "\nSetup aws s3 endpoint url:-\n"
 aws configure set s3.endpoint_url $endpoint_url
 check_status "Failed to set awscli s3 endpoint url."
+echo -e "\nSetup default aws region:-\n"
+aws configure set region us-west-2
+check_status "Failed to set default aws region."
 aws configure set s3api.endpoint_url $endpoint_url
 check_status "Failed to set awscli s3 api endpoint url."
 echo -e "\nSetup aws access key:-\n"
@@ -54,9 +57,7 @@ check_status "Failed to set awscli access key."
 echo -e "\nSetup aws secret key:-\n"
 aws configure set aws_secret_access_key $secret_key
 check_status "Failed to set awscli secret key."
-
 cat /root/.aws/config
-
 add_separator Successfully configured awscli.
 
 add_separator Starting IO testing.

--- a/solutions/kubernetes/io-testing.sh
+++ b/solutions/kubernetes/io-testing.sh
@@ -47,7 +47,7 @@ echo -e "\nSetup aws s3 endpoint url:-\n"
 aws configure set s3.endpoint_url $endpoint_url
 check_status "Failed to set awscli s3 endpoint url."
 echo -e "\nSetup default aws region:-\n"
-aws configure set region us-west-2
+aws configure set default.region us-east-1
 check_status "Failed to set default aws region."
 aws configure set s3api.endpoint_url $endpoint_url
 check_status "Failed to set awscli s3 api endpoint url."


### PR DESCRIPTION
# Problem Statement
- Deployment is failing in few cases if default AWS region is not set. Added command to set default aws region.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM -  https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/757/ and https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/756/console

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide