### PR TITLE
CORTX-29309:Update consul and jq software version 

### DIFF
--- a/docker/cortx-deploy/cortx-control/third-party-rpms.txt
+++ b/docker/cortx-deploy/cortx-control/third-party-rpms.txt
@@ -1,11 +1,12 @@
 crontabs  #cortx-utils
 java-1.8.0-openjdk-headless
-jq #cortx-prvsnr
+jq-1.6-3 #cortx-prvsnr #cortx-hare
 which #cortx-motr
 libfabric-1.11.2 #cortx-motr
 python3-ldap #cortx-utils
 sshpass
 sudo
-python3-dbus 
-python3-m2crypto 
+python3-dbus
+python3-m2crypto
 python3-psutil
+consul-1.11.4 #cortx-hare

--- a/docker/cortx-deploy/cortx-control/third-party-rpms.txt
+++ b/docker/cortx-deploy/cortx-control/third-party-rpms.txt
@@ -1,6 +1,6 @@
 crontabs  #cortx-utils
 java-1.8.0-openjdk-headless
-jq-1.6-3 #cortx-prvsnr #cortx-hare
+jq #cortx-prvsnr #cortx-hare
 which #cortx-motr
 libfabric-1.11.2 #cortx-motr
 python3-ldap #cortx-utils

--- a/docker/cortx-deploy/cortx-data/third-party-rpms.txt
+++ b/docker/cortx-deploy/cortx-data/third-party-rpms.txt
@@ -1,11 +1,12 @@
 crontabs  #cortx-utils
 java-1.8.0-openjdk-headless
-jq #cortx-prvsnr
+jq-1.6-3 #cortx-prvsnr #cortx-hare
 which #cortx-motr
 libfabric-1.11.2 #cortx-motr
 python3-ldap #cortx-utils
 sshpass
 sudo
-python3-dbus 
-python3-m2crypto 
+python3-dbus
+python3-m2crypto
 python3-psutil
+consul-1.11.4 #cortx-hare

--- a/docker/cortx-deploy/cortx-data/third-party-rpms.txt
+++ b/docker/cortx-deploy/cortx-data/third-party-rpms.txt
@@ -1,6 +1,6 @@
 crontabs  #cortx-utils
 java-1.8.0-openjdk-headless
-jq-1.6-3 #cortx-prvsnr #cortx-hare
+jq #cortx-prvsnr #cortx-hare
 which #cortx-motr
 libfabric-1.11.2 #cortx-motr
 python3-ldap #cortx-utils

--- a/docker/cortx-deploy/cortx-rgw/third-party-rpms.txt
+++ b/docker/cortx-deploy/cortx-rgw/third-party-rpms.txt
@@ -1,6 +1,6 @@
 crontabs  #cortx-utils
 java-1.8.0-openjdk-headless
-jq-1.6-3 #cortx-prvsnr #cortx-hare
+jq #cortx-prvsnr #cortx-hare
 which #cortx-motr
 libfabric-1.11.2 #cortx-motr
 gperftools-libs

--- a/docker/cortx-deploy/cortx-rgw/third-party-rpms.txt
+++ b/docker/cortx-deploy/cortx-rgw/third-party-rpms.txt
@@ -1,6 +1,6 @@
 crontabs  #cortx-utils
 java-1.8.0-openjdk-headless
-jq #cortx-prvsnr
+jq-1.6-3 #cortx-prvsnr #cortx-hare
 which #cortx-motr
 libfabric-1.11.2 #cortx-motr
 gperftools-libs
@@ -16,6 +16,7 @@ smartmontools
 python3-ldap #cortx-utils
 sshpass
 sudo
-python3-dbus 
-python3-m2crypto 
+python3-dbus
+python3-m2crypto
 python3-psutil
+consul-1.11.4 #cortx-hare

--- a/docker/cortx-deploy/rockylinux-8.4/third-party-rpms.txt
+++ b/docker/cortx-deploy/rockylinux-8.4/third-party-rpms.txt
@@ -1,6 +1,6 @@
 crontabs  #cortx-utils
 java-1.8.0-openjdk-headless
-jq-1.6-3 #cortx-prvsnr #cortx-hare
+jq #cortx-prvsnr #cortx-hare
 logrotate #cortx-utils
 python36
 python3-dbus

--- a/docker/cortx-deploy/rockylinux-8.4/third-party-rpms.txt
+++ b/docker/cortx-deploy/rockylinux-8.4/third-party-rpms.txt
@@ -1,6 +1,6 @@
 crontabs  #cortx-utils
 java-1.8.0-openjdk-headless
-jq #cortx-prvsnr
+jq-1.6-3 #cortx-prvsnr #cortx-hare
 logrotate #cortx-utils
 python36
 python3-dbus
@@ -11,3 +11,4 @@ sudo
 which #cortx-motr
 python3-ldap #cortx-utils
 libfabric-1.11.2 #cortx-motr
+consul-1.11.4 #cortx-hare


### PR DESCRIPTION
Consul version update to 1.11.4 is required for getting some fixes from
hashicorp project, which are required to resolve some issues seen in
cortx project - one such issue is - CORTX-28823.
Jq version update is required for the issue seen - CORTX-29150

### Specification of requested package

Details | Values
------ | ------
Package Name  |  consul 
Version | 1.11.4
license | hashicorp consul
Source  | https://www.consul.io/downloads


Details | Values
------ | ------
Package Name  | jq
Version | 1.6-3
license |
Source  | http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/jq-1.6-3.el8.x86_64.rpm

### Please add below details about package

* [x] Purpose of using new SW ?
To resolve some issues seen in cortx project - one such issue is - CORTX-28823.
* [x] Location of the source code of new opensource SW ?
consul:- https://www.consul.io/downloads
jq:- http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/jq-1.6-3.el8.x86_64.rpm
* [x] Did you evaluate existing SW and confirm they do not serve the purpose ? If yes, include the comparison. If no, why ?
consul:- https://www.consul.io/docs/k8s/upgrade
* [ ] Who is building it or how it gets built ? If yes, Which component/rpm will it be included ? i.e. name of the rpm which includes SW.
* [x] Download location of opensource software package ?
consul:- https://www.consul.io/downloads
jq:- http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/jq-1.6-3.el8.x86_64.rpm
* [ ] Who will be supporting this package ?
* [ ] Is there a configuration required for this? Who will be configuring it ?
* [ ] Which component is responsible for deploying on nodes ?
* [ ] What is the licensing policy ? Is it approved by legal ? 