### PR TITLE
CORTX-29510: Updated jq install and removed yq.

### DIFF
--- a/scripts/rgw/ceph/README.md
+++ b/scripts/rgw/ceph/README.md
@@ -25,3 +25,7 @@ popd
 ```
 
 As per template, ceph.spec file is now updated at line no.: 146, 147, 162 and 676.
+
+Use the following command to build rpms:
+`time rpmbuild --clean --rmsource --define "_unpackaged_files_terminate_build 0" --define "debug_package %{nil}" --define "_binary_payload w2T16.xzdio" --define "_topdir `pwd`" --without seastar --without cephfs_java --without ceph_test_package --without selinux --without lttng  --without cephfs_shell  --without amqp_endpoint --without kafka_endpoint --without lua_packages --without zbd --without cmake_verbose_logging --without rbd_rwl_cache --without rbd_ssd_cache  --without system_pmdk --without jaeger --without ocf --without make_check -vv -ba ./SPECS/ceph.spec
+`

--- a/scripts/rgw/ceph/README.md
+++ b/scripts/rgw/ceph/README.md
@@ -27,5 +27,6 @@ popd
 As per template, ceph.spec file is now updated at line no.: 146, 147, 162 and 676.
 
 Use the following command to build rpms:
-`time rpmbuild --clean --rmsource --define "_unpackaged_files_terminate_build 0" --define "debug_package %{nil}" --define "_binary_payload w2T16.xzdio" --define "_topdir `pwd`" --without seastar --without cephfs_java --without ceph_test_package --without selinux --without lttng  --without cephfs_shell  --without amqp_endpoint --without kafka_endpoint --without lua_packages --without zbd --without cmake_verbose_logging --without rbd_rwl_cache --without rbd_ssd_cache  --without system_pmdk --without jaeger --without ocf --without make_check -vv -ba ./SPECS/ceph.spec
-`
+```
+time rpmbuild --clean --rmsource --define "_unpackaged_files_terminate_build 0" --define "debug_package %{nil}" --define "_binary_payload w2T16.xzdio" --define "_topdir `pwd`" --without seastar --without cephfs_java --without ceph_test_package --without selinux --without lttng  --without cephfs_shell  --without amqp_endpoint --without kafka_endpoint --without lua_packages --without zbd --without cmake_verbose_logging --without rbd_rwl_cache --without rbd_ssd_cache  --without system_pmdk --without jaeger --without ocf --without make_check -vv -ba ./SPECS/ceph.spec
+```

--- a/solutions/kubernetes/cluster-functions.sh
+++ b/solutions/kubernetes/cluster-functions.sh
@@ -169,7 +169,7 @@ function install_prerequisites() {
         # Stop and disable firewalld
         (systemctl stop firewalld && systemctl disable firewalld && sudo systemctl mask --now firewalld) || throw $Exception
         # Install python packages
-        (yum install python3-pip yum-utils wget jq -y && pip3 install --upgrade pip && wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/local/bin/jq) || throw $Exception
+        (yum install python3-pip yum-utils wget jq -y && pip3 install --upgrade pip && pip3 install jq) || throw $Exception
 
         CURRENT_OS=$(cut -d ' ' -f 1,4 < /etc/redhat-release)
         if [ "$CURRENT_OS" == "Rocky 8.4" ]; then

--- a/solutions/kubernetes/cluster-functions.sh
+++ b/solutions/kubernetes/cluster-functions.sh
@@ -169,7 +169,7 @@ function install_prerequisites() {
         # Stop and disable firewalld
         (systemctl stop firewalld && systemctl disable firewalld && sudo systemctl mask --now firewalld) || throw $Exception
         # Install python packages
-        (yum install python3-pip yum-utils wget jq -y && pip3 install --upgrade pip && pip3 install jq yq) || throw $Exception
+        (yum install python3-pip yum-utils wget jq -y && pip3 install --upgrade pip && wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/local/bin/jq) || throw $Exception
 
         CURRENT_OS=$(cut -d ' ' -f 1,4 < /etc/redhat-release)
         if [ "$CURRENT_OS" == "Rocky 8.4" ]; then

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -117,7 +117,7 @@ function setup_cluster() {
 }
 
 function support_bundle() {
-    add_primary_separator "Collect CORTX Support Bundle Logs"
+    add_primary_separator "\tCollect CORTX Support Bundle Logs"
     ssh_primary_node '/var/tmp/cortx-deploy-functions.sh --generate-logs'
 }
 


### PR DESCRIPTION
Signed-off-by: Nitish Singh <nitish.singh@seagate.com>

# Problem Statement
- pip3 install jq command failing on hp21-r12 server

# Design
-  Removed pip yq installation as it's not used anywhere in k8s cluster setup and cortx-deploy-functions.sh removes pre-installed yq.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- Single node vm k8s setup: https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_k8s_setup/165
- 3 node vm:  https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/nitisdev/job/test_k8s_setup/164

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide