### PR TITLE
CORTX-29649 Update parameter for prereq-deploy-cortx-cloud.sh

### DIFF
--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -232,7 +232,7 @@ function execute_prereq() {
     docker pull $CORTX_DATA_IMAGE || { echo "Failed to pull $CORTX_DATA_IMAGE"; exit 1; }
     pushd $SCRIPT_LOCATION/k8_cortx_cloud
         findmnt $SYSTEM_DRIVE && umount -l $SYSTEM_DRIVE
-        ./prereq-deploy-cortx-cloud.sh $SYSTEM_DRIVE
+        ./prereq-deploy-cortx-cloud.sh -d $SYSTEM_DRIVE
     popd    
 }
 


### PR DESCRIPTION
# Problem Statement
- prereq-deploy-cortx-cloud.sh is failing due to incorrect parameters  Error shown are as below. Refer https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/1709/console
```
19:18:06  ssc-vm-rhev4-1838: ERROR: Invalid input parameters
19:18:06  ssc-vm-rhev4-1838: 
19:18:06  ssc-vm-rhev4-1838: Usage:
19:18:06  ssc-vm-rhev4-1838:     prereq-deploy-cortx-cloud.sh -d DISK [-s SOLUTION_CONFIG_FILE] [-p] [[-b] [-c SEPARATOR]]
19:18:06  ssc-vm-rhev4-1838:     prereq-deploy-cortx-cloud.sh -h
19:18:06  ssc-vm-rhev4-1838: 
19:18:06  ssc-vm-rhev4-1838: Options:
19:18:06  ssc-vm-rhev4-1838:     -h              Prints this help information.
19:18:06  ssc-vm-rhev4-1838: 
19:18:06  ssc-vm-rhev4-1838:     -d <DISK>       REQUIRED. The path of the disk or device to mount for
19:18:06  ssc-vm-rhev4-1838:                     secondary storage.
19:18:06  ssc-vm-rhev4-1838: 
19:18:06  ssc-vm-rhev4-1838:     -s <FILE>       The cluster solution configuration file. Can
19:18:06  ssc-vm-rhev4-1838:                     also be set with the CORTX_SOLUTION_CONFIG_FILE
19:18:06  ssc-vm-rhev4-1838:                     environment variable. Defaults to 'solution.yaml'.
19:18:06  ssc-vm-rhev4-1838: 
19:18:06  ssc-vm-rhev4-1838:     -p              The prereq script will attempt to update /etc/fstab
19:18:06  ssc-vm-rhev4-1838:                     with an appropriate mountpoint for persistent reboots.
19:18:06  ssc-vm-rhev4-1838: 
19:18:06  ssc-vm-rhev4-1838:     -b              Create symlinks for persistent block device access, based
19:18:06  ssc-vm-rhev4-1838:                     upon device paths defined in 'solution.yaml' and the
19:18:06  ssc-vm-rhev4-1838:                     symlink path separator defined with the '-c' option.
19:18:06  ssc-vm-rhev4-1838:                     As an example, '/dev/sdc' will have a new symlink available via
19:18:06  ssc-vm-rhev4-1838:                     '/dev/cortx/sdc' for persistent access across reboots.
19:18:06  ssc-vm-rhev4-1838:                     This option will also create an updated '{solution}-symlink.yaml'
19:18:06  ssc-vm-rhev4-1838:                     file that should be used for subsequent deployment with
19:18:06  ssc-vm-rhev4-1838:                     'deploy-cortx-cloud.sh'.
19:18:06  ssc-vm-rhev4-1838: 
19:18:06  ssc-vm-rhev4-1838:     -c              The symlink path separator used in conjunction with '-b'
19:18:06  ssc-vm-rhev4-1838:                     option to create symlinks for persistent block device access.
19:18:06  ssc-vm-rhev4-1838:                     Defaults to 'cortx'.
```

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM - Tested using - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/1737/console

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide