### PR TITLE
CORTX-29737: logrotate rpm is not available in cortx-data pod of corx…

### DIFF
--- a/docker/cortx-deploy/cortx-data/third-party-rpms.txt
+++ b/docker/cortx-deploy/cortx-data/third-party-rpms.txt
@@ -10,3 +10,4 @@ python3-dbus
 python3-m2crypto
 python3-psutil
 consul-1.11.4 #cortx-hare
+logrotate


### PR DESCRIPTION
…tx docker image

Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

# Problem Statement
- To provide logrotate functionality in data pods, logrotate rpm is needed in data pods.

# Design
In data pod, motr will call logrotate in hourly basis through cron

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide