### PR TITLE
CORTX-29737: logrotate rpm is not available in cortx-data pod of corx…

### DIFF
--- a/docker/cortx-deploy/cortx-data/third-party-rpms.txt
+++ b/docker/cortx-deploy/cortx-data/third-party-rpms.txt
@@ -10,3 +10,4 @@ python3-dbus
 python3-m2crypto
 python3-psutil
 consul-1.11.4 #cortx-hare
+logrotate


### PR DESCRIPTION
logrotate rpm is not available in cortx-data pod of cortx-data docker image

Signed-off-by: Atul Deshmukh <atul.deshmukh@seagate.com>

### Specification of requested package

Details | Values
------ | ------
Package Name  | logrotate 
Version | 3.14.0-4.el8.x86_64
license | GPLv2+
Source  | https://vault.centos.org/8.5.2111/BaseOS/Source/SPackages/logrotate-3.14.0-4.el8.src.rpm 


### Please add below details about package

* [x] Purpose of using new SW ?
       To rotate motr logs. 
* [x] Location of the source code of new opensource SW ?
       https://vault.centos.org/8.5.2111/BaseOS/Source/SPackages/logrotate-3.14.0-4.el8.src.rpm
* [x] Did you evaluate existing SW and confirm they do not serve the purpose ? If yes, include the comparison. If no, why ?
       logrotate rpm is needed to rotate the logs which is not available in current data pod.
* [x] Who is building it or how it gets built ? If yes, Which component/rpm will it be included ? i.e. name of the rpm which includes SW.
       RE team builds the library and creates RPM from the source
* [x] Download location of opensource software package ?
       https://vault.centos.org/8.5.2111/BaseOS/Source/SPackages/logrotate-3.14.0-4.el8.src.rpm
* [x] Who will be supporting this package ?
       Linux distribution e.g. centos
* [x] Is there a configuration required for this? Who will be configuring it ?
       No
* [x] Which component is responsible for deploying on nodes ?
       DevOps (RE)
* [x] What is the licensing policy ? Is it approved by legal ? 
       GPLv2+.  It is Legal.