### PR TITLE
CORTX-30701 Community build cortx-rgw build is failing

### DIFF
--- a/docker/cortx-build/Makefile
+++ b/docker/cortx-build/Makefile
@@ -21,8 +21,8 @@ checkout:
 	@echo "*************** checkout code *********************"
 	pushd cortx-workspace && \
         for component in cortx-motr cortx-hare cortx-rgw-integration cortx-manager cortx-utils cortx-ha; do pushd $$component; git clean -fdx; git checkout .; git pull -p --all; git checkout $$BRANCH || exit 1; popd ; done  && \
-		# Cloning cortx-rgw separatley as with submodule clone does not work
-		git clone https://github.com/Seagate/cortx-rgw -b $$BRANCH
+		rm -rf cortx-rgw && \
+		git clone https://github.com/Seagate/cortx-rgw -b $$BRANCH && \
 	popd || (echo "ERROR: Failed to checkout specified branch/tag Exiting..."; exit 1)
 
 ## clean: remove existing /var/artifacts/0 directory. 

--- a/docker/cortx-build/Makefile
+++ b/docker/cortx-build/Makefile
@@ -20,7 +20,9 @@ help : Makefile
 checkout:
 	@echo "*************** checkout code *********************"
 	pushd cortx-workspace && \
-        for component in $$(ls -1d cortx-* | grep -Evx 'cortx-k8s||cortx-experiments||cortx-posix||cortx-multisite||cortx-s3samplecode'); do pushd $$component; git clean -fdx; git checkout .; git pull -p --all; git checkout $$BRANCH || exit 1; popd ; done  && \
+        for component in cortx-motr cortx-hare cortx-rgw-integration cortx-manager cortx-utils cortx-ha; do pushd $$component; git clean -fdx; git checkout .; git pull -p --all; git checkout $$BRANCH || exit 1; popd ; done  && \
+		# Cloning cortx-rgw separatley as with submodule clone does not work
+		git clone https://github.com/Seagate/cortx-rgw -b $$BRANCH
 	popd || (echo "ERROR: Failed to checkout specified branch/tag Exiting..."; exit 1)
 
 ## clean: remove existing /var/artifacts/0 directory. 


### PR DESCRIPTION
# Problem Statement
-  CORTX RGW build steps is failing for community-build instructions from https://github.com/Seagate/cortx/blob/main/doc/community-build/docker/cortx-all/README.md 
    Error reported is 
```
Complete!
make-dist: Full path to the script: /cortx-workspace/cortx-rgw/make-dist
make-dist: No .git present. Run this from the base dir of the git checkout.
ERROR: cortx-rgw source code is not available in cortx-workspace. Exiting...
make: *** [Makefile:181: _cortx-rgw_prereq] Error 1
```

We have added [cortx-rgw](https://github.com/Seagate/cortx-rgw) as a submodule to [cortx](https://github.com/Seagate/cortx/) repo as part of https://github.com/Seagate/cortx/pull/1387. cortx-rgw itself has a submodule structure that is not working in `make-dist` execution. To fix this added code to clone cortx-rgw repo separately. 


# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM  - Tested manually following https://github.com/Seagate/cortx/blob/main/doc/community-build/docker/cortx-all/README.md . Few changed needed in this doc also. I will raise PR for cortx repo to fix them.

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide