### PR TITLE
CORTX-29518 : Add test plans in py-utils pre-merge job

### DIFF
--- a/jenkins/internal-ci/generic/pr/cortx_deployment/pyutils.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/pyutils.groovy
@@ -27,7 +27,7 @@ pipeline {
             name: 'CORTX_IMAGE'
         )
         choice (
-            choices: ['kv_store', 'sanity'],
+            choices: ['sanity','regression','audit_log','cli_framework','cmd_framework','conf_store','consul_service','iem_framework','kv_store','message_bus','support_bundle','validator'],
             description: 'Test plan to be executed for py-utils. Defaults to kv_store',
             name: 'TEST_PLAN'
         )

--- a/jenkins/internal-ci/generic/pr/cortx_deployment/pyutils.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/pyutils.groovy
@@ -28,7 +28,7 @@ pipeline {
         )
         choice (
             choices: ['sanity','regression','audit_log','cli_framework','cmd_framework','conf_store','consul_service','iem_framework','kv_store','message_bus','support_bundle','validator'],
-            description: 'Test plan to be executed for py-utils. Defaults to kv_store',
+            description: 'Test plan to be executed for py-utils. Defaults to sanity',
             name: 'TEST_PLAN'
         )
     }


### PR DESCRIPTION
# Problem Statement
- All test plans were not added in py-utils pre-merge job

# Design
- Added remaining test plans in py-utils pre-merge job

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
   https://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Cortx-Deployment/job/Generic/job/py-utils-test/114/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide