### PR TITLE
CORTX-30961 Use Calico v3.20.1 to fix current K8s setup failure

### DIFF
--- a/solutions/kubernetes/cluster-functions.sh
+++ b/solutions/kubernetes/cluster-functions.sh
@@ -20,7 +20,7 @@
 
 source /var/tmp/functions.sh
 
-CALICO_PLUGIN_VERSION=latest
+CALICO_PLUGIN_VERSION=v3.20.1
 K8_VERSION=1.22.6
 DOCKER_VERSION=latest
 OS_VERSION=( "CentOS 7.9.2009" "Rocky 8.4" )


### PR DESCRIPTION
# Problem Statement
-  We are using the latest Calico v3.22.2. It's causing the issue in the Calico pod setup with the below error,
```
[root@ssc-vm-g4-rhev4-1296 ~]# kubectl -n kube-system  logs calico-node-pks22
2022-04-21 11:18:28.951 [INFO][9] startup/startup.go 425: Early log level set to info
2022-04-21 11:18:28.952 [INFO][9] startup/utils.go 127: Using NODENAME environment for node name ssc-vm-g4-rhev4-1296.colo.seagate.com
2022-04-21 11:18:28.952 [INFO][9] startup/utils.go 139: Determined node name: ssc-vm-g4-rhev4-1296.colo.seagate.com
2022-04-21 11:18:28.952 [INFO][9] startup/startup.go 94: Starting node ssc-vm-g4-rhev4-1296.colo.seagate.com with version v3.22.2
2022-04-21 11:18:28.954 [INFO][9] startup/startup.go 430: Checking datastore connection
2022-04-21 11:18:28.970 [INFO][9] startup/startup.go 454: Datastore connection verified
2022-04-21 11:18:28.970 [INFO][9] startup/startup.go 104: Datastore is ready
2022-04-21 11:18:28.976 [INFO][9] startup/customresource.go 102: Error getting resource Key=GlobalFelixConfig(name=CalicoVersion) Name="calicoversion" Resource="GlobalFelixConfigs" error=the server could not find the requested resource (get GlobalFelixConfigs.crd.projectcalico.org calicoversion)
2022-04-21 11:18:28.992 [INFO][9] startup/autodetection_methods.go 103: Using autodetected IPv4 address on interface eth4: 192.168.84.206/19
2022-04-21 11:18:28.992 [INFO][9] startup/startup.go 699: No AS number configured on node resource, using global value
2022-04-21 11:18:29.002 [INFO][9] startup/startup.go 744: found v4= in the kubeadm config map
2022-04-21 11:18:29.002 [INFO][9] startup/startup.go 748: found v6= in the kubeadm config map
2022-04-21 11:18:29.003 [INFO][9] startup/startup.go 815: Selected default IP pool is '172.16.0.0/16'
2022-04-21 11:18:29.003 [INFO][9] startup/startup.go 680: CALICO_IPV4POOL_NAT_OUTGOING is true (defaulted) through environment variable
2022-04-21 11:18:29.003 [INFO][9] startup/startup.go 901: Ensure default IPv4 pool is created. IPIP mode: Always, VXLAN mode: Never
2022-04-21 11:18:29.008 [ERROR][9] startup/startup.go 907: Failed to create default IPv4 IP pool: 172.16.0.0/16 error=resource does not exist: FelixConfiguration(default) with error: the server could not find the requested resource (post FelixConfigurations.crd.projectcalico.org)
2022-04-21 11:18:29.008 [WARNING][9] startup/utils.go 49: Terminating
Calico node failed to start
[root@ssc-vm-g4-rhev4-1296 ~]#
```
Reverted to Calico v3.20.1 to fix this issue. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM  - 
1N - K8s Setup - https://eos-jenkins.colo.seagate.com/job/Cortx-Kubernetes/job/setup-kubernetes-cluster/3682/console 
1N - CORTX Setup - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/2959/console
3N - K8s Setup - https://eos-jenkins.colo.seagate.com/job/Cortx-Kubernetes/job/setup-kubernetes-cluster/3683/console
3N - CORTX Setup - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/2960/console

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide