### PR TITLE
CORTX-30946 Nightly Job to exclude further stages in case of deployment failure

### DIFF
--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -58,36 +58,32 @@ pipeline {
         
         stage ("Deploy CORTX Cluster") {
             steps {
-                catchError(stageResult: 'FAILURE') {
-                    script { build_stage = env.STAGE_NAME }
-                    script {
-                        def cortxCluster = build job: '/Cortx-Automation/RGW/setup-cortx-rgw-cluster', wait: true,
-                        parameters: [
-                            string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                            string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_REPO}"),
-                            string(name: 'CORTX_ALL_IMAGE', value: "${CORTX_ALL_IMAGE}"),
-                            string(name: 'CORTX_SERVER_IMAGE', value: "${CORTX_SERVER_IMAGE}"),
-                            string(name: 'CORTX_DATA_IMAGE', value: "${CORTX_DATA_IMAGE}"),
-                            string(name: 'DEPLOYMENT_METHOD', value: "standard"),
-                            text(name: 'hosts', value: "${hosts}"),
-                            string(name: 'CORTX_SCRIPTS_BRANCH', value: "${CORTX_SCRIPTS_BRANCH}"),
-                            string(name: 'CORTX_SCRIPTS_REPO', value: "${CORTX_SCRIPTS_REPO}"),
-                            string(name: 'EXTERNAL_EXPOSURE_SERVICE', value: "NodePort"),
-                            string(name: 'SNS_CONFIG', value: "${SNS_CONFIG}"),
-                            string(name: 'DIX_CONFIG', value: "${DIX_CONFIG}")
-                        ]
-                        env.cortxcluster_build_url = cortxCluster.absoluteUrl
-                        env.cortxCluster_status = cortxCluster.currentResult
-                    }
+                script { build_stage = env.STAGE_NAME }
+                script {
+                    def cortxCluster = build job: '/Cortx-Automation/RGW/setup-cortx-rgw-cluster', wait: true,
+                    parameters: [
+                        string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
+                        string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_REPO}"),
+                        string(name: 'CORTX_ALL_IMAGE', value: "${CORTX_ALL_IMAGE}"),
+                        string(name: 'CORTX_SERVER_IMAGE', value: "${CORTX_SERVER_IMAGE}"),
+                        string(name: 'CORTX_DATA_IMAGE', value: "${CORTX_DATA_IMAGE}"),
+                        string(name: 'DEPLOYMENT_METHOD', value: "standard"),
+                        text(name: 'hosts', value: "${hosts}"),
+                        string(name: 'CORTX_SCRIPTS_BRANCH', value: "${CORTX_SCRIPTS_BRANCH}"),
+                        string(name: 'CORTX_SCRIPTS_REPO', value: "${CORTX_SCRIPTS_REPO}"),
+                        string(name: 'EXTERNAL_EXPOSURE_SERVICE', value: "NodePort"),
+                        string(name: 'SNS_CONFIG', value: "${SNS_CONFIG}"),
+                        string(name: 'DIX_CONFIG', value: "${DIX_CONFIG}")
+                    ]
+                    env.cortxcluster_build_url = cortxCluster.absoluteUrl
+                    env.cortxCluster_status = cortxCluster.currentResult
                 }
             }
         }
 
         stage('Push Image to GitHub') {
             agent {
-                node {
-                label 'docker-image-builder-centos-7.9.2009'
-                }
+                node { label 'docker-image-builder-centos-7.9.2009' }
             }
            steps {
                 sh label: 'Push Image to GitHub', script: '''                   


### PR DESCRIPTION
# Problem Statement
- Nightly Job continues to upload images to GitHub even if deployment is failing. Refer - https://eos-jenkins.colo.seagate.com/job/Cortx-Deployment/job/Nightly-K8s-Deploy/747/console  . Removed Try-Catch block which is causing issue. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM - Deployment Failing job is exiting out - https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/nightly-ci-cd/328/parameters/ 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide