### PR TITLE
CORTX-31080 : Add option to skip fresh builds for management components

### DIFF
--- a/jenkins/custom-ci/generic/cortx-ha.groovy
+++ b/jenkins/custom-ci/generic/cortx-ha.groovy
@@ -22,6 +22,11 @@ pipeline {
         string(name: 'CORTX_UTILS_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for CORTX Utils', trim: true)
         string(name: 'CORTX_UTILS_URL', defaultValue: 'https://github.com/Seagate/cortx-utils', description: 'CORTX Utils Repository URL', trim: true)
         string(name: 'THIRD_PARTY_PYTHON_VERSION', defaultValue: 'custom', description: 'Third Party Python Version to use', trim: true)
+        choice(
+            name: 'BUILD_LATEST_CORTX_HA',
+            choices: ['yes', 'no'],
+            description: 'Build cortx-ha from latest code or use last-successful build.'
+        )
         // Add os_version parameter in jenkins configuration
     }
     
@@ -35,6 +40,7 @@ pipeline {
 
     stages {
         stage('Checkout') {
+            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 dir ('cortx-ha') {
@@ -50,6 +56,7 @@ pipeline {
 
         // Install third-party dependencies. This needs to be removed once components move away from self-contained binaries 
         stage('Install python packages') {
+            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: '', script: '''
@@ -71,6 +78,7 @@ EOF
 
 
         stage('Install Dependencies') {
+            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: '', script: '''
@@ -89,6 +97,7 @@ EOF
         }
 
         stage('Build') {
+            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Build', script: '''
@@ -101,6 +110,7 @@ EOF
         }
         
         stage('Test') {
+            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Test', script: '''
@@ -118,7 +128,12 @@ EOF
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''
                     mkdir -p $build_upload_dir
-                    cp $WORKSPACE/cortx-ha/dist/rpmbuild/RPMS/*/*.rpm $build_upload_dir
+                    if [ "$BUILD_LATEST_CORTX_HA" == "yes" ]; then
+                        cp $WORKSPACE/cortx-ha/dist/rpmbuild/RPMS/*/*.rpm $build_upload_dir
+                    else
+                        echo "Copy packages form last_successful"
+                        cp /mnt/bigstorage/releases/cortx/components/github/main/rockylinux-8.4/dev/cortx-ha/last_successful/*.rpm $build_upload_dir
+                    fi    
                 '''
             }
         } 

--- a/jenkins/custom-ci/generic/cortx-ha.groovy
+++ b/jenkins/custom-ci/generic/cortx-ha.groovy
@@ -22,11 +22,6 @@ pipeline {
         string(name: 'CORTX_UTILS_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for CORTX Utils', trim: true)
         string(name: 'CORTX_UTILS_URL', defaultValue: 'https://github.com/Seagate/cortx-utils', description: 'CORTX Utils Repository URL', trim: true)
         string(name: 'THIRD_PARTY_PYTHON_VERSION', defaultValue: 'custom', description: 'Third Party Python Version to use', trim: true)
-        choice(
-            name: 'BUILD_LATEST_CORTX_HA',
-            choices: ['yes', 'no'],
-            description: 'Build cortx-ha from latest code or use last-successful build.'
-        )
         // Add os_version parameter in jenkins configuration
     }
     
@@ -40,7 +35,6 @@ pipeline {
 
     stages {
         stage('Checkout') {
-            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 dir ('cortx-ha') {
@@ -56,7 +50,6 @@ pipeline {
 
         // Install third-party dependencies. This needs to be removed once components move away from self-contained binaries 
         stage('Install python packages') {
-            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: '', script: '''
@@ -78,7 +71,6 @@ EOF
 
 
         stage('Install Dependencies') {
-            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: '', script: '''
@@ -97,7 +89,6 @@ EOF
         }
 
         stage('Build') {
-            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Build', script: '''
@@ -110,7 +101,6 @@ EOF
         }
         
         stage('Test') {
-            when { expression { params.BUILD_LATEST_CORTX_HA == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Test', script: '''
@@ -128,12 +118,7 @@ EOF
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''
                     mkdir -p $build_upload_dir
-                    if [ "$BUILD_LATEST_CORTX_HA" == "yes" ]; then
-                        cp $WORKSPACE/cortx-ha/dist/rpmbuild/RPMS/*/*.rpm $build_upload_dir
-                    else
-                        echo "Copy packages form last_successful"
-                        cp /mnt/bigstorage/releases/cortx/components/github/main/rockylinux-8.4/dev/cortx-ha/last_successful/*.rpm $build_upload_dir
-                    fi    
+                    cp $WORKSPACE/cortx-ha/dist/rpmbuild/RPMS/*/*.rpm $build_upload_dir    
                 '''
             }
         } 

--- a/jenkins/custom-ci/generic/cortx-py-utils.groovy
+++ b/jenkins/custom-ci/generic/cortx-py-utils.groovy
@@ -10,11 +10,6 @@ pipeline {
         string(name: 'CORTX_UTILS_URL', defaultValue: 'https://github.com/Seagate/cortx-utils', description: 'Repository URL for cortx-py-utils build')
         string(name: 'CORTX_UTILS_BRANCH', defaultValue: 'stable', description: 'Branch for cortx-py-utils build')
         string(name: 'CUSTOM_CI_BUILD_ID', defaultValue: '0', description: 'Custom CI Build Number')
-        choice(
-            name: 'BUILD_LATEST_CORTX_UTILS',
-            choices: ['yes', 'no'],
-            description: 'Build cortx-utils from latest code or use last-successful build.'
-        )
         // Add os_version parameter in jenkins configuration
     }
     
@@ -37,7 +32,6 @@ pipeline {
     stages {
     
         stage('Checkout py-utils') {
-            when { expression { params.BUILD_LATEST_CORTX_UTILS == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 checkout([$class: 'GitSCM', branches: [[name: "${CORTX_UTILS_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'AuthorInChangelog']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', url: "${CORTX_UTILS_URL}"]]])
@@ -45,7 +39,6 @@ pipeline {
         }
     
         stage('Build') {
-            when { expression { params.BUILD_LATEST_CORTX_UTILS == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Build', script: '''
@@ -63,15 +56,10 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''
                     mkdir -p $build_upload_dir
-                    if [ "$BUILD_LATEST_CORTX_UTILS" == "yes" ]; then
-                        shopt -s extglob
-                        cp ./py-utils/dist/!(*.src.rpm|*.tar.gz) $build_upload_dir
-                        cp ./statsd-utils/dist/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir
-                        createrepo -v --update $build_upload_dir
-                    else
-                        echo "Copy packages form last_successful"
-                        cp /mnt/bigstorage/releases/cortx/components/github/main/rockylinux-8.4/dev/cortx-utils/last_successful/*.rpm $build_upload_dir
-                    fi    
+                    shopt -s extglob
+                    cp ./py-utils/dist/!(*.src.rpm|*.tar.gz) $build_upload_dir
+                    cp ./statsd-utils/dist/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir
+                    createrepo -v --update $build_upload_dir    
                 '''
             }
         }

--- a/jenkins/custom-ci/generic/csm-agent.groovy
+++ b/jenkins/custom-ci/generic/csm-agent.groovy
@@ -29,11 +29,6 @@ pipeline {
         string(name: 'CORTX_UTILS_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for CORTX Utils', trim: true)
         string(name: 'CORTX_UTILS_URL', defaultValue: 'https://github.com/Seagate/cortx-utils', description: 'CORTX Utils Repository URL', trim: true)
         string(name: 'THIRD_PARTY_PYTHON_VERSION', defaultValue: 'cortx-2.0', description: 'Third Party Python Version to use', trim: true)
-        choice(
-            name: 'BUILD_LATEST_CSM_AGENT',
-            choices: ['yes', 'no'],
-            description: 'Build cortx-management from latest code or use last-successful build.'
-        )
         // Add os_version parameter in jenkins configuration
     }    
 
@@ -41,7 +36,6 @@ pipeline {
     stages {
 
         stage('Checkout') {
-            when { expression { params.BUILD_LATEST_CSM_AGENT == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 dir('cortx-manager') {
@@ -57,7 +51,6 @@ pipeline {
         }
         
         stage('Install Dependencies') {
-            when { expression { params.BUILD_LATEST_CSM_AGENT == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
 
@@ -78,7 +71,6 @@ pipeline {
         }    
         
         stage('Build') {
-            when { expression { params.BUILD_LATEST_CSM_AGENT == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 // Exclude return code check for csm_setup and csm_test
@@ -100,12 +92,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''
                     mkdir -p $build_upload_dir
-                    if [ "$BUILD_LATEST_CSM_AGENT" == "yes" ]; then
-                        cp ./cortx-manager/dist/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir
-                    else
-                        echo "Copy packages form last_successful"
-                        cp /mnt/bigstorage/releases/cortx/components/github/main/rockylinux-8.4/dev/csm-agent/last_successful/*.rpm $build_upload_dir
-                    fi    
+                    cp ./cortx-manager/dist/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir    
                 '''
             }
         }

--- a/jenkins/custom-ci/generic/csm-agent.groovy
+++ b/jenkins/custom-ci/generic/csm-agent.groovy
@@ -29,6 +29,11 @@ pipeline {
         string(name: 'CORTX_UTILS_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for CORTX Utils', trim: true)
         string(name: 'CORTX_UTILS_URL', defaultValue: 'https://github.com/Seagate/cortx-utils', description: 'CORTX Utils Repository URL', trim: true)
         string(name: 'THIRD_PARTY_PYTHON_VERSION', defaultValue: 'cortx-2.0', description: 'Third Party Python Version to use', trim: true)
+        choice(
+            name: 'BUILD_LATEST_CSM_AGENT',
+            choices: ['yes', 'no'],
+            description: 'Build cortx-management from latest code or use last-successful build.'
+        )
         // Add os_version parameter in jenkins configuration
     }    
 
@@ -36,7 +41,7 @@ pipeline {
     stages {
 
         stage('Checkout') {
-            
+            when { expression { params.BUILD_LATEST_CSM_AGENT == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 dir('cortx-manager') {
@@ -52,6 +57,7 @@ pipeline {
         }
         
         stage('Install Dependencies') {
+            when { expression { params.BUILD_LATEST_CSM_AGENT == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
 
@@ -72,6 +78,7 @@ pipeline {
         }    
         
         stage('Build') {
+            when { expression { params.BUILD_LATEST_CSM_AGENT == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 // Exclude return code check for csm_setup and csm_test
@@ -93,7 +100,12 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''
                     mkdir -p $build_upload_dir
-                    cp ./cortx-manager/dist/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir
+                    if [ "$BUILD_LATEST_CSM_AGENT" == "yes" ]; then
+                        cp ./cortx-manager/dist/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir
+                    else
+                        echo "Copy packages form last_successful"
+                        cp /mnt/bigstorage/releases/cortx/components/github/main/rockylinux-8.4/dev/csm-agent/last_successful/*.rpm $build_upload_dir
+                    fi    
                 '''
             }
         }

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -89,11 +89,11 @@ pipeline {
         choice(
             name: 'BUILD_MANAGEMENT_PATH_COMPONENTS',
             choices: ['yes', 'no'],
-            description: '''<pre>
-            Build cortx-management, cortx-ha, cortx-provisioner and cortx-py-utils from latest code or use last-successful build.
-            If you select <strong>no</strong>, below parameter values will get ignored
+            description: '''
+            Build cortx-management, cortx-ha, cortx-provisioner and cortx-py-utils from latest code or use last-successful build.<br>
+            If you select <strong>no</strong>, below parameter values will get ignored<br>
             <strong>CSM_AGENT_BRANCH, CSM_AGENT_URL, HA_BRANCH, HA_URL, PRVSNR_BRANCH, PRVSNR_URL, CORTX_UTILS_BRANCH, CORTX_UTILS_URL</strong>
-            </pre>'''
+            '''
         )
 
     }

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -264,7 +264,7 @@ pipeline {
                     fi
 
                     pushd $RPM_COPY_PATH
-                    for component in `ls -1 | grep -E -v "$CUSTOM_COMPONENT_NAME" | grep -E -v 'luster|halon|mero|motr|csm|cortx-extension|nfs|cortx-utils|cortx-prereq'`
+                    for component in `ls -1 | grep -E -v "$CUSTOM_COMPONENT_NAME" | grep -E -v 'luster|halon|mero|motr|cortx-extension|nfs|cortx-utils|cortx-prereq'`
                     do
                         echo -e "Copying RPM's for $component"
                         if ls $component/last_successful/*.rpm 1> /dev/null 2>&1; then

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -105,7 +105,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 script {
                     try {
-                        def cortx_utils_build = build job: '/Release_Engineering/re-workspace/custom-cortx-py-utils-temp', wait: true,
+                        def cortx_utils_build = build job: '/GitHub-custom-ci-builds/generic/custom-cortx-py-utils', wait: true,
                         parameters: [
                             string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
                             string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
@@ -125,7 +125,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 script {
                     try {
-                        def prvsnrbuild = build job: '/Release_Engineering/re-workspace/custom-cortx-prvsnr-temp', wait: true,
+                        def prvsnrbuild = build job: '/GitHub-custom-ci-builds/generic/prvsnr-custom-build', wait: true,
                         parameters: [
                             string(name: 'PRVSNR_URL', value: "${PRVSNR_URL}"),
                             string(name: 'PRVSNR_BRANCH', value: "${PRVSNR_BRANCH}"),
@@ -205,7 +205,7 @@ pipeline {
                         script { build_stage = env.STAGE_NAME }
                         script {
                             try {
-                                def habuild = build job: '/Release_Engineering/re-workspace/custom-cortx-ha-temp', wait: true,
+                                def habuild = build job: '/GitHub-custom-ci-builds/generic/cortx-ha-custom-build', wait: true,
                                           parameters: [
                                               string(name: 'HA_URL', value: "${HA_URL}"),
                                               string(name: 'HA_BRANCH', value: "${HA_BRANCH}"),
@@ -228,7 +228,7 @@ pipeline {
                         script { build_stage = env.STAGE_NAME }
                         script {
                             try {
-                                def csm_agent_build = build job: '/Release_Engineering/re-workspace/custom-csm-agent-temp', wait: true,
+                                def csm_agent_build = build job: '/GitHub-custom-ci-builds/generic/custom-csm-agent-build', wait: true,
                                               parameters: [
                                                     string(name: 'CSM_AGENT_URL', value: "${CSM_AGENT_URL}"),
                                                     string(name: 'CSM_AGENT_BRANCH', value: "${CSM_AGENT_BRANCH}"),

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -89,11 +89,11 @@ pipeline {
         choice(
             name: 'BUILD_MANAGEMENT_PATH_COMPONENTS',
             choices: ['yes', 'no'],
-            description: '''
+            description: '''<pre>
             Build cortx-management, cortx-ha, cortx-provisioner and cortx-py-utils from latest code or use last-successful build.
             If you select <strong>no</strong>, below parameter values will get ignored
             <strong>CSM_AGENT_BRANCH, CSM_AGENT_URL, HA_BRANCH, HA_URL, PRVSNR_BRANCH, PRVSNR_URL, CORTX_UTILS_BRANCH, CORTX_UTILS_URL</strong>
-            '''
+            </pre>'''
         )
 
     }

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -90,9 +90,9 @@ pipeline {
             name: 'BUILD_MANAGEMENT_PATH_COMPONENTS',
             choices: ['yes', 'no'],
             description: '''
-            Build cortx-management, cortx-ha, cortx-provisioner and cortx-py-utils from latest code or use last-successful build.<br>
+            Build cortx-management, cortx-ha and cortx-provisioner from latest code or use last-successful build.<br>
             If you select <strong>no</strong>, below parameter values will get ignored<br>
-            <strong>CSM_AGENT_BRANCH, CSM_AGENT_URL, HA_BRANCH, HA_URL, PRVSNR_BRANCH, PRVSNR_URL, CORTX_UTILS_BRANCH, CORTX_UTILS_URL</strong>
+            <strong>CSM_AGENT_BRANCH, CSM_AGENT_URL, HA_BRANCH, HA_URL, PRVSNR_BRANCH, PRVSNR_URL</strong>
             '''
         )
 
@@ -101,7 +101,6 @@ pipeline {
     stages {
 
         stage ("Build CORTX Utils") {
-            when { expression { params.BUILD_MANAGEMENT_PATH_COMPONENTS == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 script {
@@ -262,6 +261,7 @@ pipeline {
                         CUSTOM_COMPONENT_NAME="motr|hare|cortx-ha|provisioner|csm-agent|cortx-utils|cortx-rgw|cortx-rgw-integration"
                     else
                         CUSTOM_COMPONENT_NAME="motr|hare|cortx-rgw|cortx-rgw-integration"    
+                    fi
 
                     pushd $RPM_COPY_PATH
                     for component in `ls -1 | grep -E -v "$CUSTOM_COMPONENT_NAME" | grep -E -v 'luster|halon|mero|motr|csm|cortx-extension|nfs|cortx-utils|cortx-prereq'`

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -101,6 +101,7 @@ pipeline {
     stages {
 
         stage ("Build CORTX Utils") {
+            when { expression { params.BUILD_MANAGEMENT_PATH_COMPONENTS == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 script {
@@ -109,8 +110,7 @@ pipeline {
                         parameters: [
                             string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
                             string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
-                            string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
-                            string(name: 'BUILD_LATEST_CORTX_UTILS', value: "${BUILD_MANAGEMENT_PATH_COMPONENTS}")
+                            string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}")
                         ]
                     } catch (err) {
                         build_stage = env.STAGE_NAME
@@ -121,6 +121,7 @@ pipeline {
         }
 
         stage ("Build Provisioner") {
+            when { expression { params.BUILD_MANAGEMENT_PATH_COMPONENTS == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                 script {
@@ -129,8 +130,7 @@ pipeline {
                         parameters: [
                             string(name: 'PRVSNR_URL', value: "${PRVSNR_URL}"),
                             string(name: 'PRVSNR_BRANCH', value: "${PRVSNR_BRANCH}"),
-                            string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
-                            string(name: 'BUILD_LATEST_CORTX_PROVISIONER', value: "${BUILD_MANAGEMENT_PATH_COMPONENTS}")
+                            string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}")
                         ]
                     } catch (err) {
                         build_stage = env.STAGE_NAME
@@ -201,6 +201,7 @@ pipeline {
                 }
 
                 stage ("Build HA") {
+                    when { expression { params.BUILD_MANAGEMENT_PATH_COMPONENTS == 'yes' } }
                     steps {
                         script { build_stage = env.STAGE_NAME }
                         script {
@@ -212,8 +213,7 @@ pipeline {
                                               string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
                                               string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
                                               string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
-                                              string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}"),
-                                              string(name: 'BUILD_LATEST_CORTX_HA', value: "${BUILD_MANAGEMENT_PATH_COMPONENTS}")
+                                              string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}")
                                           ]
                             } catch (err) {
                                 build_stage = env.STAGE_NAME
@@ -224,6 +224,7 @@ pipeline {
                 }
 
                 stage ("Build CSM Agent") {
+                    when { expression { params.BUILD_MANAGEMENT_PATH_COMPONENTS == 'yes' } }
                     steps {
                         script { build_stage = env.STAGE_NAME }
                         script {
@@ -235,8 +236,7 @@ pipeline {
                                                     string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
                                                     string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
                                                     string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
-                                                    string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}"),
-                                                    string(name: 'BUILD_LATEST_CSM_AGENT', value: "${BUILD_MANAGEMENT_PATH_COMPONENTS}")
+                                                    string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}")
                                               ]
                             } catch (err) {
                                 build_stage = env.STAGE_NAME
@@ -258,7 +258,10 @@ pipeline {
                 sh label: 'Copy RPMS', script:'''
                     RPM_COPY_PATH="/mnt/bigstorage/releases/cortx/components/github/main/$os_version/dev/"
 
-                    CUSTOM_COMPONENT_NAME="motr|s3server|hare|cortx-ha|provisioner|csm-agent|csm-web|sspl|cortx-utils|cortx-rgw|cortx-rgw-integration"
+                    if [ "$BUILD_MANAGEMENT_PATH_COMPONENTS" == "yes" ]; then
+                        CUSTOM_COMPONENT_NAME="motr|hare|cortx-ha|provisioner|csm-agent|cortx-utils|cortx-rgw|cortx-rgw-integration"
+                    else
+                        CUSTOM_COMPONENT_NAME="motr|hare|cortx-rgw|cortx-rgw-integration"    
 
                     pushd $RPM_COPY_PATH
                     for component in `ls -1 | grep -E -v "$CUSTOM_COMPONENT_NAME" | grep -E -v 'luster|halon|mero|motr|csm|cortx-extension|nfs|cortx-utils|cortx-prereq'`

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -86,6 +86,24 @@ pipeline {
             description: 'Build cortx-rgw from latest code or use last-successful build.'
         )
 
+        choice(
+            name: 'BUILD_LATEST_CORTX_UTILS',
+            choices: ['yes', 'no'],
+            description: 'Build cortx-utils from latest code or use last-successful build.'
+        )
+
+        choice(
+            name: 'BUILD_LATEST_CORTX_HA',
+            choices: ['yes', 'no'],
+            description: 'Build cortx-ha from latest code or use last-successful build.'
+        )
+
+        choice(
+            name: 'BUILD_LATEST_CSM_AGENT',
+            choices: ['yes', 'no'],
+            description: 'Build cortx-management from latest code or use last-successful build.'
+        )
+
     }
 
     stages {
@@ -99,7 +117,8 @@ pipeline {
                         parameters: [
                             string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
                             string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
-                            string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}")
+                            string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
+                            string(name: 'BUILD_LATEST_CORTX_UTILS', value: "${BUILD_LATEST_CORTX_UTILS}")
                         ]
                     } catch (err) {
                         build_stage = env.STAGE_NAME
@@ -179,7 +198,7 @@ pipeline {
                                               string(name: 'CORTX_RGW_INTEGRATION_URL', value: "${CORTX_RGW_INTEGRATION_URL}"),
                                               string(name: 'CORTX_RGW_INTEGRATION_BRANCH', value: "${CORTX_RGW_INTEGRATION_BRANCH}"),
                                               string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}")
-                                                ]
+                                          ]
                             } catch (err) {
                                 build_stage = env.STAGE_NAME
                                 error "Failed to Build RGW Integration"
@@ -200,8 +219,9 @@ pipeline {
                                               string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
                                               string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
                                               string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
-                                              string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}")
-                                                ]
+                                              string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}"),
+                                              string(name: 'BUILD_LATEST_CORTX_HA', value: "${BUILD_LATEST_CORTX_HA}")
+                                          ]
                             } catch (err) {
                                 build_stage = env.STAGE_NAME
                                 error "Failed to Build HA"
@@ -222,7 +242,8 @@ pipeline {
                                                     string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
                                                     string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
                                                     string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
-                                                    string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}")
+                                                    string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}"),
+                                                    string(name: 'BUILD_LATEST_CSM_AGENT', value: "${BUILD_LATEST_CSM_AGENT}")
                                               ]
                             } catch (err) {
                                 build_stage = env.STAGE_NAME

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -87,21 +87,9 @@ pipeline {
         )
 
         choice(
-            name: 'BUILD_LATEST_CORTX_UTILS',
-            choices: ['yes', 'no'],
-            description: 'Build cortx-utils from latest code or use last-successful build.'
-        )
-
-        choice(
-            name: 'BUILD_LATEST_CORTX_HA',
-            choices: ['yes', 'no'],
-            description: 'Build cortx-ha from latest code or use last-successful build.'
-        )
-
-        choice(
-            name: 'BUILD_LATEST_CSM_AGENT',
-            choices: ['yes', 'no'],
-            description: 'Build cortx-management from latest code or use last-successful build.'
+            name: 'BUILD_MANAGEMENT_PATH_COMPONENTS',
+            choices: ['no', 'yes'],
+            description: 'Build cortx-management, cortx-ha, cortx-provisioner and cortx-py-utils from latest code or use last-successful build.'
         )
 
     }
@@ -118,7 +106,7 @@ pipeline {
                             string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
                             string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
                             string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
-                            string(name: 'BUILD_LATEST_CORTX_UTILS', value: "${BUILD_LATEST_CORTX_UTILS}")
+                            string(name: 'BUILD_LATEST_CORTX_UTILS', value: "${BUILD_MANAGEMENT_PATH_COMPONENTS}")
                         ]
                     } catch (err) {
                         build_stage = env.STAGE_NAME
@@ -135,9 +123,10 @@ pipeline {
                     try {
                         def prvsnrbuild = build job: '/GitHub-custom-ci-builds/generic/prvsnr-custom-build', wait: true,
                         parameters: [
-                        string(name: 'PRVSNR_URL', value: "${PRVSNR_URL}"),
-                        string(name: 'PRVSNR_BRANCH', value: "${PRVSNR_BRANCH}"),
-                        string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}")
+                            string(name: 'PRVSNR_URL', value: "${PRVSNR_URL}"),
+                            string(name: 'PRVSNR_BRANCH', value: "${PRVSNR_BRANCH}"),
+                            string(name: 'CUSTOM_CI_BUILD_ID', value: "${BUILD_NUMBER}"),
+                            string(name: 'BUILD_LATEST_CORTX_PROVISIONER', value: "${BUILD_MANAGEMENT_PATH_COMPONENTS}")
                         ]
                     } catch (err) {
                         build_stage = env.STAGE_NAME
@@ -220,7 +209,7 @@ pipeline {
                                               string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
                                               string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
                                               string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}"),
-                                              string(name: 'BUILD_LATEST_CORTX_HA', value: "${BUILD_LATEST_CORTX_HA}")
+                                              string(name: 'BUILD_LATEST_CORTX_HA', value: "${BUILD_MANAGEMENT_PATH_COMPONENTS}")
                                           ]
                             } catch (err) {
                                 build_stage = env.STAGE_NAME
@@ -243,7 +232,7 @@ pipeline {
                                                     string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
                                                     string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
                                                     string(name: 'THIRD_PARTY_PYTHON_VERSION', value: "${THIRD_PARTY_PYTHON_VERSION}"),
-                                                    string(name: 'BUILD_LATEST_CSM_AGENT', value: "${BUILD_LATEST_CSM_AGENT}")
+                                                    string(name: 'BUILD_LATEST_CSM_AGENT', value: "${BUILD_MANAGEMENT_PATH_COMPONENTS}")
                                               ]
                             } catch (err) {
                                 build_stage = env.STAGE_NAME

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -105,7 +105,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 script {
                     try {
-                        def cortx_utils_build = build job: '/GitHub-custom-ci-builds/generic/custom-cortx-py-utils', wait: true,
+                        def cortx_utils_build = build job: '/Release_Engineering/re-workspace/custom-cortx-py-utils-temp', wait: true,
                         parameters: [
                             string(name: 'CORTX_UTILS_URL', value: "${CORTX_UTILS_URL}"),
                             string(name: 'CORTX_UTILS_BRANCH', value: "${CORTX_UTILS_BRANCH}"),
@@ -125,7 +125,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 script {
                     try {
-                        def prvsnrbuild = build job: '/GitHub-custom-ci-builds/generic/prvsnr-custom-build', wait: true,
+                        def prvsnrbuild = build job: '/Release_Engineering/re-workspace/custom-cortx-prvsnr-temp', wait: true,
                         parameters: [
                             string(name: 'PRVSNR_URL', value: "${PRVSNR_URL}"),
                             string(name: 'PRVSNR_BRANCH', value: "${PRVSNR_BRANCH}"),
@@ -205,7 +205,7 @@ pipeline {
                         script { build_stage = env.STAGE_NAME }
                         script {
                             try {
-                                def habuild = build job: '/GitHub-custom-ci-builds/generic/cortx-ha-custom-build', wait: true,
+                                def habuild = build job: '/Release_Engineering/re-workspace/custom-cortx-ha-temp', wait: true,
                                           parameters: [
                                               string(name: 'HA_URL', value: "${HA_URL}"),
                                               string(name: 'HA_BRANCH', value: "${HA_BRANCH}"),
@@ -228,7 +228,7 @@ pipeline {
                         script { build_stage = env.STAGE_NAME }
                         script {
                             try {
-                                def csm_agent_build = build job: '/GitHub-custom-ci-builds/generic/custom-csm-agent-build', wait: true,
+                                def csm_agent_build = build job: '/Release_Engineering/re-workspace/custom-csm-agent-temp', wait: true,
                                               parameters: [
                                                     string(name: 'CSM_AGENT_URL', value: "${CSM_AGENT_URL}"),
                                                     string(name: 'CSM_AGENT_BRANCH', value: "${CSM_AGENT_BRANCH}"),
@@ -456,7 +456,7 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 script {
                     try {
-                        def build_cortx_all_image = build job: 'cortx-all-docker-image', wait: true,
+                        def build_cortx_all_image = build job: 'GitHub-custom-ci-builds/generic/cortx-all-docker-image/', wait: true,
                                     parameters: [
                                         string(name: 'CORTX_RE_URL', value: "${CORTX_RE_URL}"),
                                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -88,8 +88,12 @@ pipeline {
 
         choice(
             name: 'BUILD_MANAGEMENT_PATH_COMPONENTS',
-            choices: ['no', 'yes'],
-            description: 'Build cortx-management, cortx-ha, cortx-provisioner and cortx-py-utils from latest code or use last-successful build.'
+            choices: ['yes', 'no'],
+            description: '''
+            Build cortx-management, cortx-ha, cortx-provisioner and cortx-py-utils from latest code or use last-successful build.
+            If you select <strong>no</strong>, below parameter values will get ignored
+            <strong>CSM_AGENT_BRANCH, CSM_AGENT_URL, HA_BRANCH, HA_URL, PRVSNR_BRANCH, PRVSNR_URL, CORTX_UTILS_BRANCH, CORTX_UTILS_URL</strong>
+            '''
         )
 
     }

--- a/jenkins/custom-ci/generic/provisioner.groovy
+++ b/jenkins/custom-ci/generic/provisioner.groovy
@@ -10,6 +10,11 @@ pipeline {
         string(name: 'PRVSNR_URL', defaultValue: 'https://github.com/Seagate/cortx-prvsnr', description: 'Repository URL for Provisioner.')
         string(name: 'PRVSNR_BRANCH', defaultValue: 'main', description: 'Branch for Provisioner.')
         string(name: 'CUSTOM_CI_BUILD_ID', defaultValue: '0', description: 'Custom CI Build Number')
+        choice(
+            name: 'BUILD_LATEST_CORTX_PROVISIONER',
+            choices: ['yes', 'no'],
+            description: 'Build cortx-provisioner from latest code or use last-successful build.'
+        )
         // Add os_version parameter in jenkins configuration
     }
 
@@ -30,6 +35,7 @@ pipeline {
 
     stages {
         stage('Checkout') {
+            when { expression { params.BUILD_LATEST_CORTX_PROVISIONER == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
                     checkout([$class: 'GitSCM', branches: [[name: "${PRVSNR_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'AuthorInChangelog']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'cortx-admin-github', url: "${PRVSNR_URL}"]]])
@@ -37,6 +43,7 @@ pipeline {
         }
 
         stage('Build') {
+            when { expression { params.BUILD_LATEST_CORTX_PROVISIONER == 'yes' } }
             steps {
                 script { build_stage = env.STAGE_NAME }
 
@@ -55,12 +62,16 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 sh label: 'Copy RPMS', script: '''
                     mkdir -p $build_upload_dir
-                    #cp /root/rpmbuild/RPMS/x86_64/*.rpm $build_upload_dir
                     shopt -s extglob
-                    if ls ./dist/*.rpm; then
-                        cp ./dist/!(*.src.rpm|*.tar.gz) $build_upload_dir
-                    fi
-                    createrepo -v --update $build_upload_dir
+                    if [ "$BUILD_LATEST_CORTX_PROVISIONER" == "yes" ]; then
+                        if ls ./dist/*.rpm; then
+                            cp ./dist/!(*.src.rpm|*.tar.gz) $build_upload_dir
+                        fi
+                        createrepo -v --update $build_upload_dir
+                    else
+                        echo "Copy packages form last_successful"
+                        cp /mnt/bigstorage/releases/cortx/components/github/main/rockylinux-8.4/dev/provisioner/last_successful/*.rpm $build_upload_dir
+                    fi    
                 '''
             }
         }


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

# Problem Statement
- csm, ha, provisioner rpms get built everytime and increase total build time.

# Design
-  Provide option to freshly build csm, ha, provisioner rpm or else take it from last successful build.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
   custom-ci - https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/custom-ci-test/223/
  Deployment using images generated by above custom-ci - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/4377/
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide