### PR TITLE
CORTX-31398 Community Build is failing while Motr dependency installation.

### DIFF
--- a/docker/cortx-build/Makefile
+++ b/docker/cortx-build/Makefile
@@ -96,6 +96,7 @@ _cortx-motr_prereq:
 		sed -i "/BuildRequires.*%{lustre_devel}/d" cortx-motr.spec && \
 		sed -i 's/@BUILD_DEPEND_LIBFAB@//g' cortx-motr.spec && \
 		sed -i 's/@.*@/111/g' cortx-motr.spec && \
+		yum install --setopt=cortx-build-dependencies.module_hotfixes=true --disablerepo='appstream' castxml -y && \
 		yum-builddep -y --nogpgcheck cortx-motr.spec && \
 		yum -y --nogpgcheck --disablerepo='baseos' --disablerepo='powertools' install libfabric-1.11.2 libfabric-devel-1.11.2 && \
 	popd || (echo "ERROR: cortx-motr source code is not available in cortx-workspace. Exiting..."; exit 1)


### PR DESCRIPTION
# Problem Statement
- Community Build was failing in the installation of `castxml` package. This is an issue due to dependency management in the EPEL repo. Raised https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2087619 for this. To fix this issue added the required packages in https://github.com/Seagate/cortx/releases/tag/build-dependencies 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM  - Tested locally
- [ ] Jenkins pipelines used for testing

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
