### PR TITLE
CORTX-31410 : Add overall regression status in nightly deployment

### DIFF
--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -152,7 +152,6 @@ pipeline {
                         env.Sanity_Failed = qaSanity.buildVariables.Sanity_Failed
                         env.Sanity_status = qaSanity.buildVariables.Sanity_Failed.toString() == 'true' ? 'Failed' : qaSanity.buildVariables.Sanity_Failed.toString() == 'false' ? 'Passed' : 'Skipped'
                         env.Regression_Failed = qaSanity.buildVariables.Regression_Failed
-                        env.Regression_overall_failed = = qaSanity.buildVariables.Regression_overall_failed
                         env.Regression_overall_status = qaSanity.buildVariables.Regression_overall_failed.toString() == 'true' ? 'Failed' : qaSanity.buildVariables.Regression_overall_failed.toString() == 'false' ? 'Passed' : 'Skipped'
                         env.Io_Path_Failed = qaSanity.buildVariables.Io_Path_Failed
                         env.Failure_Domain_Failed = qaSanity.buildVariables.Failure_Domain_Failed
@@ -193,7 +192,7 @@ pipeline {
                     currentBuild.result = "SUCCESS"
                 } else if ( "${env.cortxCluster_status}" == "FAILURE" || "${env.cortxCluster_status}" == "UNSTABLE" || "${env.cortxCluster_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=failed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_failed}"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=failed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "SKIPPED"
@@ -201,14 +200,14 @@ pipeline {
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" || "${env.qaSanity_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_failed}"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "FAILURE"
                     env.deployment_result = "SUCCESS"
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "UNSTABLE" ) {
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_failed}"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
                     ICON = "unstable.gif"
                     STATUS = "UNSTABLE"
                     env.deployment_result = "SUCCESS"

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -152,7 +152,8 @@ pipeline {
                         env.Sanity_Failed = qaSanity.buildVariables.Sanity_Failed
                         env.Sanity_status = qaSanity.buildVariables.Sanity_Failed.toString() == 'true' ? 'Failed' : qaSanity.buildVariables.Sanity_Failed.toString() == 'false' ? 'Passed' : 'Skipped'
                         env.Regression_Failed = qaSanity.buildVariables.Regression_Failed
-                        env.Regression_status = qaSanity.buildVariables.Regression_Failed.toString() == 'true' ? 'Failed' : qaSanity.buildVariables.Regression_Failed.toString() == 'false' ? 'Passed' : 'Skipped'
+                        env.Regression_overall_failed = = qaSanity.buildVariables.Regression_overall_failed
+                        env.Regression_overall_status = qaSanity.buildVariables.Regression_overall_failed.toString() == 'true' ? 'Failed' : qaSanity.buildVariables.Regression_overall_failed.toString() == 'false' ? 'Passed' : 'Skipped'
                         env.Io_Path_Failed = qaSanity.buildVariables.Io_Path_Failed
                         env.Failure_Domain_Failed = qaSanity.buildVariables.Failure_Domain_Failed
                         env.sanity_result = qaSanity.currentResult
@@ -165,6 +166,7 @@ pipeline {
                         env.failcount = qaSanity.buildVariables.failcount
                         env.skipcount = qaSanity.buildVariables.skipcount
                         env.todocount = qaSanity.buildVariables.todocount
+
                     }
                     copyArtifacts filter: 'log/*report.xml', fingerprintArtifacts: true, flatten: true, optional: true, projectName: 'QA-Sanity-Multinode-RGW', selector: lastCompleted(), target: 'log/'
                     copyArtifacts filter: 'log/*report.html', fingerprintArtifacts: true, flatten: true, optional: true, projectName: 'QA-Sanity-Multinode-RGW', selector: lastCompleted(), target: 'log/'
@@ -191,7 +193,7 @@ pipeline {
                     currentBuild.result = "SUCCESS"
                 } else if ( "${env.cortxCluster_status}" == "FAILURE" || "${env.cortxCluster_status}" == "UNSTABLE" || "${env.cortxCluster_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=failed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_status}"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=failed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_failed}"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "SKIPPED"
@@ -199,14 +201,14 @@ pipeline {
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" || "${env.qaSanity_status}" == "null" ) {
                     manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_status}"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_failed}"
                     ICON = "error.gif"
                     STATUS = "FAILURE"
                     env.sanity_result = "FAILURE"
                     env.deployment_result = "SUCCESS"
                     currentBuild.result = "FAILURE"
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "UNSTABLE" ) {
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_status}"
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_failed}"
                     ICON = "unstable.gif"
                     STATUS = "UNSTABLE"
                     env.deployment_result = "SUCCESS"

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -165,7 +165,7 @@ pipeline {
                         env.failcount = qaSanity.buildVariables.failcount
                         env.skipcount = qaSanity.buildVariables.skipcount
                         env.todocount = qaSanity.buildVariables.todocount
-
+                        env.abortcount = qaSanity.buildVariables.abortcount
                     }
                     copyArtifacts filter: 'log/*report.xml', fingerprintArtifacts: true, flatten: true, optional: true, projectName: 'QA-Sanity-Multinode-RGW', selector: lastCompleted(), target: 'log/'
                     copyArtifacts filter: 'log/*report.html', fingerprintArtifacts: true, flatten: true, optional: true, projectName: 'QA-Sanity-Multinode-RGW', selector: lastCompleted(), target: 'log/'


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

# Problem Statement
- Multiple regression status inputs are coming from QA job and hence it is difficult to provide overall regression status

# Design
-  Take overall regression status from QA job and provide it to email template

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [ ] Jenkins pipelines used for testing

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
