### PR TITLE
CORTX-31968 - Add cortx-re githash in CORTX image label

### DIFF
--- a/docker/cortx-deploy/build.sh
+++ b/docker/cortx-deploy/build.sh
@@ -88,11 +88,13 @@ echo -e "########################################################"
 
 function get_git_hash {
 sed -i '/KERNEL/d' RELEASE.INFO
-for component in cortx-py-utils cortx-s3server cortx-motr cortx-hare cortx-provisioner
+for component in cortx-py-utils cortx-motr cortx-hare cortx-provisioner cortx-ha cortx-rgw-integration
 do
     echo $component:"$(awk -F['_'] '/'$component'-'$VERSION'/ { print $2 }' RELEASE.INFO | cut -d. -f1 | sed 's/git//g')",
 done
 echo cortx-csm_agent:"$(awk -F['_'] '/cortx-csm_agent-'$VERSION'/ { print $3 }' RELEASE.INFO | cut -d. -f1)",
+echo cortx-rgw:"$(awk -F['-'] '/'ceph-base'/{ print $5  }' RELEASE.INFO | cut -d. -f2)",
+echo cortx-re:"$(git rev-parse --short HEAD)",
 }
 
 curl -s $BUILD_URL/RELEASE.INFO -o RELEASE.INFO

--- a/docker/cortx-deploy/generate-release-info.sh
+++ b/docker/cortx-deploy/generate-release-info.sh
@@ -34,7 +34,7 @@ $(sed 's/^/    /g' "/opt/seagate/cortx/compatibility.info")
 COMPONENTS:
 $(for component in $(sed 's/#.*//g' /opt/seagate/cortx/cortx-component-rpms.txt /opt/seagate/cortx/ceph-component-rpms.txt); do echo "    - \"$(rpm -q $component).rpm\"" ; done)
 THIRD_PARTY_RPM_PACKAGES:
-$(for component in $(sed 's/#.*//g' /opt/seagate/cortx/third-party-rpms.txt); do echo "    - \"$(rpm -q $component).rpm\"" ; done)
+$(for component in $(while read -r component; do grep "$component" < /opt/seagate/cortx/third-party-rpms.txt; done </opt/seagate/cortx/cortx-component-rpms.txt | sed 's/#.*//g'); do echo "    - \"$(rpm -q $component).rpm\"" ; done)
 THIRD_PARTY_PYTHON_PACKAGES:
 $(pip3 freeze | sed 's/^/    - /g')
 EOF

--- a/scripts/release_support/changelog.sh
+++ b/scripts/release_support/changelog.sh
@@ -18,6 +18,8 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+#set -eo pipefail
+
 START_BUILD=$1
 TARGET_BUILD=$2
 BUILD_LOCATION=$3
@@ -37,13 +39,13 @@ if [ -z "$START_BUILD" ]; then echo "No START_BUILD provided.."; exit 1 ; fi
 if [ -z "$TARGET_BUILD" ]; then echo "No TARGET_BUILD provided.."; exit 1; fi
 
 declare -A COMPONENT_LIST=(
-[cortx-motr]="https://github.com/Seagate/cortx-motr.git"
-[cortx-hare]="https://github.com/Seagate/cortx-hare.git"
-[cortx-ha]="https://github.com/Seagate/cortx-ha.git"
-[cortx-provisioner]="https://github.com/Seagate/cortx-prvsnr.git"
-[cortx-csm_agent]="https://github.com/Seagate/cortx-manager.git"
-[cortx-py-utils]="https://github.com/Seagate/cortx-utils.git"
-[cortx-rgw-integration]="https://github.com/Seagate/cortx-rgw-integration.git"
+[cortx-motr]="https://github.com/Seagate/cortx-motr"
+[cortx-hare]="https://github.com/Seagate/cortx-hare"
+[cortx-ha]="https://github.com/Seagate/cortx-ha"
+[cortx-provisioner]="https://github.com/Seagate/cortx-prvsnr"
+[cortx-csm_agent]="https://github.com/Seagate/cortx-manager"
+[cortx-py-utils]="https://github.com/Seagate/cortx-utils"
+[cortx-rgw-integration]="https://github.com/Seagate/cortx-rgw-integration"
 [ceph-base]="https://github.com/Seagate/cortx-rgw"
 )
 
@@ -115,14 +117,17 @@ do
 
                  pushd "$dir" || exit
 
-                        echo -e "\t--[ Check-ins for $dir from $START_BUILD ($start_hash) to $TARGET_BUILD ($target_hash) ]--" >> $report_file
-                        echo -e "Githash|Description|Author|" >> $report_file
-                        change="$(git log "$start_hash..$target_hash" --oneline --pretty=format:"%h|%cd|%s|%an|")";
+#                        echo -e "\t--[ Check-ins for $dir from $START_BUILD ($start_hash) to $TARGET_BUILD ($target_hash) ]--" >> $report_file
+#                        echo -e "Githash|Description|Author|" >> $report_file
+                        change="$(git log "$start_hash..$target_hash" --oneline --pretty=format:"%s")";
                 if [ "$change" ]; then
                         echo "$change" >> $report_file
-                        else
-                        echo -e "No Changes" >> $report_file
-                        echo -e "---------------------------------------------------------------------------------------------" >> $report_file
+                        GITHUB_URL="${COMPONENT_LIST[$component]}"
+                        sed -i -e s/\(#/"${GITHUB_URL//\//\\/}\/pull\/"/g -e s/\)//g  $report_file >> $report_file
+#                        sed -e s/\(#/"${GITHUB_URL//\//\\/}\/pull\/"/g -e s/\)//g  $report_file >> $report_file-converted
+#                        else
+#                        echo -e "No Changes" >> $report_file
+#                        echo -e "---------------------------------------------------------------------------------------------" >> $report_file
                 fi
          popd || exit
 


### PR DESCRIPTION
# Problem Statement
-  Added cortx-re githash in `org.opencontainers.image.revision` lable so that we can query https://github.com/Seagate/cortx-re githash used to build image. 
```
[root@ssc-vm-rhev4-0707 cortx-deploy]# docker inspect --format='{{ index .Config.Labels "org.opencontainers.image.revision"}}' cortx-rgw:2.0.0-5599
cortx-py-utils:89995d1, cortx-motr:319cc081, cortx-hare:929122f, cortx-provisioner:da8e4e7f, cortx-ha:7a5d356, cortx-rgw-integration:7e096ab, cortx-csm_agent:97ae8986, cortx-rgw:g281ff195aa7, cortx-re:842e668,
```

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - Build  - https://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/generic/job/custom-ci/6653/console and Deploy - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/6682/ 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
