### PR TITLE
CORTX-31634 Use nodeport as default service in Jenkins pipeline

### DIFF
--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -37,7 +37,7 @@ pipeline {
         text(defaultValue: '''hostname=<hostname>,user=<user>,pass=<password>''', description: 'VM details to be used for CORTX cluster setup. First node will be used as Primary node', name: 'hosts')
         choice(
             name: 'EXTERNAL_EXPOSURE_SERVICE',
-            choices: ['LoadBalancer', 'NodePort'],
+            choices: ['NodePort', 'LoadBalancer'],
             description: 'K8s Service to be used to expose RGW Service to outside cluster.'
         )
         // Please configure CORTX_SCRIPTS_BRANCH and CORTX_SCRIPTS_REPO parameter in Jenkins job configuration.


### PR DESCRIPTION
# Problem Statement
- Observed that CORTX deployment is failing with timeout with `Loadbalancer` service. Configured `nodeport` as default service in Jenkins pipeline. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/5323/consoleFull 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
