### PR TITLE
CORTX-28628 - Remove python3-ldap package from cortx-rgw image

### DIFF
--- a/docker/cortx-deploy/third-party-rpms.txt
+++ b/docker/cortx-deploy/third-party-rpms.txt
@@ -24,6 +24,5 @@ sshpass                         #cortx-py-utils
 sudo                            #cortx-py-utils
 python36                        #cortx-py-utils
 python3-dbus                    #cortx-py-utils
-python3-ldap                    #cortx-py-utils
 python3-psutil                  #cortx-py-utils
 logrotate                       #cortx-py-utils


### PR DESCRIPTION
# Problem Statement
Remove python3-ldap package from cortx-rgw image

### Specification of requested package

Details | Values
------ | ------
Package Name  |  python3-ldap
Version | 3.3.1-2.el8
license |
Source  | 
Component Team |

### Please add below details about package

* [ ] Purpose of using new SW ?  - Used for LDAP authentication which is no longer needed. 
* [ ] Location of the source code of new opensource SW ?
* [ ] Did you evaluate existing SW and confirm they do not serve the purpose ? If yes, include the comparison. If no, why ? 
* [ ] Who is building it or how it gets built ? If yes, Which component/rpm will it be included ? i.e. name of the rpm which includes SW.
* [ ] Download location of opensource software package ? python3-ldap package is removed from rgw image
* [ ] Who will be supporting this package ? 
* [ ] Is there a configuration required for this? Who will be configuring it ? No
* [ ] Which component is responsible for deploying on nodes ? RGW
* [ ] What is the licensing policy ? Is it approved by legal ? No
* [ ] Are we modifying the software or just using it as-is? No
* [ ] How are we interfacing with this software? (e.g. command-line, static link, python import, dynamic link, etc) No, 3N and IN deployment is working as expected
