### PR TITLE
CORTX-31968 - Parametrized repo_health build

### DIFF
--- a/jenkins/automation/reports/repo-health.groovy
+++ b/jenkins/automation/reports/repo-health.groovy
@@ -16,8 +16,10 @@ pipeline {
     }
 
     parameters {
-        string(name: 'CORTX_RE_BRANCH', defaultValue: 'main', description: 'Branch or GitHash to Generate Repo Health Report', trim: true)
-        string(name: 'CORTX_RE_REPO', defaultValue: 'https://github.com/Seagate/cortx-re', description: 'Repository to to Generate Repo Health Report', trim: true)
+        string(name: 'CORTX_RE_BRANCH', defaultValue: 'main', description: 'CORTX RE Branch or GitHash to Generate Repo Health Report', trim: true)
+        string(name: 'CORTX_RE_REPO', defaultValue: 'https://github.com/Seagate/cortx-re', description: 'CORTX RE Repository to to Generate Repo Health Report', trim: true)
+        string(name: 'CORTX_BRANCH', defaultValue: 'main', description: 'CORTX Branch or GitHash to Generate Repo Health Report', trim: true)
+        string(name: 'CORTX_REPO', defaultValue: 'https://github.com/Seagate/cortx', description: 'CORTX Repository to to Generate Repo Health Report', trim: true)
     }    
 
     stages {
@@ -35,6 +37,8 @@ pipeline {
                 script {
                     sh '''
                         pushd scripts/reports
+                            export CORTX_REPO=${CORTX_REPO}
+                            export CORTX_BRANCH=${CORTX_BRANCH}
                             sh ./repo-health.sh
                         popd
                     '''

--- a/scripts/reports/repo-health.sh
+++ b/scripts/reports/repo-health.sh
@@ -22,8 +22,8 @@ set -eo pipefail
 
 if [ -z "$GH_OATH" ]; then echo "GH_OATH is not set. Existing..."; exit 1; fi
 if [ -z "$CODACY_OATH" ]; then echo "CODACY_OATH is not set. Existing..."; exit 1; fi
-if [ -z "$CORTX_REPO" ]; then echo "CODACY_OATH is not set. Existing..."; exit 1; fi
-if [ -z "$CORTX_BRANCH" ]; then echo "CODACY_OATH is not set. Existing..."; exit 1; fi
+if [ -z "$CORTX_REPO" ]; then echo "CORTX_REPO is not set. Existing..."; exit 1; fi
+if [ -z "$CORTX_BRANCH" ]; then echo "CORTX_BRANCH is not set. Existing..."; exit 1; fi
 
 #Install reuired packages
 curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash

--- a/scripts/reports/repo-health.sh
+++ b/scripts/reports/repo-health.sh
@@ -22,6 +22,8 @@ set -eo pipefail
 
 if [ -z "$GH_OATH" ]; then echo "GH_OATH is not set. Existing..."; exit 1; fi
 if [ -z "$CODACY_OATH" ]; then echo "CODACY_OATH is not set. Existing..."; exit 1; fi
+if [ -z "$CORTX_REPO" ]; then echo "CODACY_OATH is not set. Existing..."; exit 1; fi
+if [ -z "$CORTX_BRANCH" ]; then echo "CODACY_OATH is not set. Existing..."; exit 1; fi
 
 #Install reuired packages
 curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash
@@ -30,7 +32,7 @@ pip3 install seaborn matplotlib pandas xlrd requests python-dateutil pyGithub ju
 git lfs install
 
 #Clone Repo
-git clone https://github.com/Seagate/cortx --depth=1
+git clone $CORTX_REPO -b $CORTX_BRANCH --depth=1
 pushd cortx && git lfs pull && popd
 
 #Execute notebook


### PR DESCRIPTION
# Problem Statement
- Repo health pipeline was hardcoded to use `main` branch and `https://github.com/Seagate/cortx` repo url. Modified it to take it as a parameter. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/Reports/job/repo-health/13/ 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
