### PR TITLE
CORTX-30156 : Add/remove cortx-control/cortx-all image support in pr deployment jobs

### DIFF
--- a/jenkins/internal-ci/generic/pr/cortx_deployment/csm-agent.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/csm-agent.groovy
@@ -244,9 +244,9 @@ pipeline {
                     parameters: [
                         string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_URL}"),
                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                        string(name: 'CORTX_ALL_IMAGE', value: "${env.cortx_all_image}"),
                         string(name: 'CORTX_SERVER_IMAGE', value: "${env.cortx_rgw_image}"),
                         string(name: 'CORTX_DATA_IMAGE', value: "${env.cortx_data_image}"),
+                        string(name: 'CORTX_CONTROL_IMAGE', value: "${env.cortx_control_image}"),
                         string(name: 'CORTX_SCRIPTS_REPO', value: "Seagate/cortx-k8s"),
                         string(name: 'CORTX_SCRIPTS_BRANCH', value: "${CORTX_SCRIPTS_BRANCH}"),
                         string(name: 'hosts', value: "${host}"),

--- a/jenkins/internal-ci/generic/pr/cortx_deployment/ha.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/ha.groovy
@@ -246,9 +246,9 @@ EOF
                     parameters: [
                         string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_URL}"),
                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                        string(name: 'CORTX_ALL_IMAGE', value: "${env.cortx_all_image}"),
                         string(name: 'CORTX_SERVER_IMAGE', value: "${env.cortx_rgw_image}"),
                         string(name: 'CORTX_DATA_IMAGE', value: "${env.cortx_data_image}"),
+                        string(name: 'CORTX_CONTROL_IMAGE', value: "${env.cortx_control_image}"),
                         string(name: 'CORTX_SCRIPTS_REPO', value: "Seagate/cortx-k8s"),
                         string(name: 'CORTX_SCRIPTS_BRANCH', value: "integration"),
                         string(name: 'hosts', value: "${host}"),

--- a/jenkins/internal-ci/generic/pr/cortx_deployment/hare.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/hare.groovy
@@ -250,9 +250,9 @@ EOF
                                   parameters: [
                                         string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_URL}"),
                                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                                        string(name: 'CORTX_ALL_IMAGE', value: "${env.cortx_all_image}"),
                                         string(name: 'CORTX_SERVER_IMAGE', value: "${env.cortx_rgw_image}"),
                                         string(name: 'CORTX_DATA_IMAGE', value: "${env.cortx_data_image}"),
+                                        string(name: 'CORTX_CONTROL_IMAGE', value: "${env.cortx_control_image}"),
                                         string(name: 'CORTX_SCRIPTS_REPO', value: "Seagate/cortx-k8s"),
                                         string(name: 'CORTX_SCRIPTS_BRANCH', value: "${CORTX_SCRIPTS_BRANCH}"),
                                         string(name: 'hosts', value: "${singlenode_host}"),
@@ -270,9 +270,9 @@ EOF
                                   parameters: [
                                         string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_URL}"),
                                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                                        string(name: 'CORTX_ALL_IMAGE', value: "${env.cortx_all_image}"),
                                         string(name: 'CORTX_SERVER_IMAGE', value: "${env.cortx_rgw_image}"),
                                         string(name: 'CORTX_DATA_IMAGE', value: "${env.cortx_data_image}"),
+                                        string(name: 'CORTX_CONTROL_IMAGE', value: "${env.cortx_control_image}"),
                                         string(name: 'CORTX_SCRIPTS_REPO', value: "Seagate/cortx-k8s"),
                                         string(name: 'CORTX_SCRIPTS_BRANCH', value: "${CORTX_SCRIPTS_BRANCH}"),
                                         string(name: 'hosts', value: "${threenode_hosts}"),

--- a/jenkins/internal-ci/generic/pr/cortx_deployment/motr.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/motr.groovy
@@ -294,9 +294,9 @@ EOF
                                   parameters: [
                                         string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_URL}"),
                                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                                        string(name: 'CORTX_ALL_IMAGE', value: "${env.cortx_all_image}"),
                                         string(name: 'CORTX_SERVER_IMAGE', value: "${env.cortx_rgw_image}"),
                                         string(name: 'CORTX_DATA_IMAGE', value: "${env.cortx_data_image}"),
+                                        string(name: 'CORTX_CONTROL_IMAGE', value: "${env.cortx_control_image}"),
                                         string(name: 'CORTX_SCRIPTS_REPO', value: "Seagate/cortx-k8s"),
                                         string(name: 'CORTX_SCRIPTS_BRANCH', value: "integration"),
                                         string(name: 'hosts', value: "${singlenode_host}"),
@@ -314,9 +314,9 @@ EOF
                                   parameters: [
                                         string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_URL}"),
                                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                                        string(name: 'CORTX_ALL_IMAGE', value: "${env.cortx_all_image}"),
                                         string(name: 'CORTX_SERVER_IMAGE', value: "${env.cortx_rgw_image}"),
                                         string(name: 'CORTX_DATA_IMAGE', value: "${env.cortx_data_image}"),
+                                        string(name: 'CORTX_CONTROL_IMAGE', value: "${env.cortx_control_image}"),
                                         string(name: 'CORTX_SCRIPTS_REPO', value: "Seagate/cortx-k8s"),
                                         string(name: 'CORTX_SCRIPTS_BRANCH', value: "integration"),
                                         string(name: 'hosts', value: "${threenode_hosts}"),

--- a/jenkins/internal-ci/generic/pr/cortx_deployment/provisioner.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/provisioner.groovy
@@ -220,9 +220,9 @@ pipeline {
                     parameters: [
                         string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_URL}"),
                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                        string(name: 'CORTX_ALL_IMAGE', value: "${env.cortx_all_image}"),
                         string(name: 'CORTX_SERVER_IMAGE', value: "${env.cortx_rgw_image}"),
                         string(name: 'CORTX_DATA_IMAGE', value: "${env.cortx_data_image}"),
+                        string(name: 'CORTX_CONTROL_IMAGE', value: "${env.cortx_control_image}"),
                         string(name: 'CORTX_SCRIPTS_REPO', value: "Seagate/cortx-k8s"),
                         string(name: 'CORTX_SCRIPTS_BRANCH', value: "${CORTX_SCRIPTS_BRANCH}"),
                         string(name: 'hosts', value: "${host}"),

--- a/jenkins/internal-ci/generic/pr/cortx_deployment/pyutils.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/pyutils.groovy
@@ -243,9 +243,9 @@ pipeline {
                     parameters: [
                         string(name: 'CORTX_RE_REPO', value: "${CORTX_RE_URL}"),
                         string(name: 'CORTX_RE_BRANCH', value: "${CORTX_RE_BRANCH}"),
-                        string(name: 'CORTX_ALL_IMAGE', value: "${env.cortx_all_image}"),
                         string(name: 'CORTX_SERVER_IMAGE', value: "${env.cortx_rgw_image}"),
                         string(name: 'CORTX_DATA_IMAGE', value: "${env.cortx_data_image}"),
+                        string(name: 'CORTX_CONTROL_IMAGE', value: "${env.cortx_control_image}"),
                         string(name: 'CORTX_SCRIPTS_REPO', value: "Seagate/cortx-k8s"),
                         string(name: 'CORTX_SCRIPTS_BRANCH', value: "${CORTX_SCRIPTS_BRANCH}"),
                         string(name: 'hosts', value: "${host}"),


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

# Problem Statement
- Deployment jobs are updated to use cortx-control image and stopped supporting cortx-all image. need to reflect these changes in PR deployment jobs.

# Design
-  Update inputs provided to deployment job from PR-build jobs.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing
   CSM - https://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Cortx-Deployment/job/Generic/job/csm-agent/376/
   Provisioner - https://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Cortx-Deployment/job/Generic/job/provisioner/209/
   Motr - https://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Cortx-Deployment/job/Generic/job/motr/840/
   Hare - https://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Cortx-Deployment/job/Generic/job/hare/446/
   HA - https://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Cortx-Deployment/job/Generic/job/ha/78/
   Py-utils -  https://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Cortx-Deployment/job/Generic/job/py-utils/361/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
