### PR TITLE
CORTX-31390 - Add performance stats in nightly performance-ci email notification

### DIFF
--- a/jenkins/performance-ci/nightly-performance-ci.groovy
+++ b/jenkins/performance-ci/nightly-performance-ci.groovy
@@ -105,7 +105,7 @@ pipeline {
         cleanup {
             script {
                 // Archive Deployment artifacts in jenkins build
-                archiveArtifacts artifacts: "*.*/perf*", onlyIfSuccessful: false, allowEmptyArchive: true 
+                archiveArtifacts artifacts: "perf*", onlyIfSuccessful: false, allowEmptyArchive: true 
             }
         }
     }

--- a/jenkins/performance-ci/nightly-performance-ci.groovy
+++ b/jenkins/performance-ci/nightly-performance-ci.groovy
@@ -105,7 +105,7 @@ pipeline {
         cleanup {
             script {
                 // Archive Deployment artifacts in jenkins build
-                archiveArtifacts artifacts: "*.*", onlyIfSuccessful: false, allowEmptyArchive: true 
+                archiveArtifacts artifacts: "*.*/perf*", onlyIfSuccessful: false, allowEmptyArchive: true 
             }
         }
     }

--- a/jenkins/performance-ci/nightly-performance-ci.groovy
+++ b/jenkins/performance-ci/nightly-performance-ci.groovy
@@ -114,6 +114,7 @@ pipeline {
                 // Jenkins Summary
                 clusterStatus = ""
                 if ( currentBuild.currentResult == "SUCCESS" ) {
+                    clusterStatus = readFile(file: '$WORKSPACE/perf_sanity_stats.txt')
                     MESSAGE = "Build#${build_id} Nightly CORTX Performance CI Success"
                     ICON = "accept.gif"
                     STATUS = "SUCCESS"
@@ -130,19 +131,19 @@ pipeline {
                     STATUS = "UNSTABLE"
                 }
                 
-                PerformaceSanityStatusHTML = "<pre>${clusterStatus}</pre>"
+                clusterStatusHTML = "<pre>${clusterStatus}</pre>"
 
-                manager.createSummary("${ICON}").appendText("<h3>Nightly CORTX Performance CI ${currentBuild.currentResult} </h3><p>Please check <a href=\"${BUILD_URL}/console\">Performance Sanity Execution logs</a> for more info <h4>Sanity Execution Logs:</h4>${PerformaceSanityStatusHTML}", false, false, false, "red")
+                manager.createSummary("${ICON}").appendText("<h3>Nightly CORTX Performance CI ${currentBuild.currentResult} </h3><p>Please check <a href=\"${BUILD_URL}/console\">Performance Sanity Execution logs</a> for more info <h4>Sanity Execution Logs:</h4>${clusterStatusHTML}", false, false, false, "red")
 
                 // Email Notification
                 env.build_stage = "${build_stage}"
-                env.cluster_status = "${PerformaceSanityStatusHTML}"
+                env.cluster_status = "${clusterStatusHTML}"
                 def recipientProvidersClass = [[$class: 'RequesterRecipientProvider']]
                 mailRecipients = "shailesh.vaidya@seagate.com"
                 emailext ( 
                     body: '''${SCRIPT, template="cluster-setup-email.template"}''',
                     mimeType: 'text/html',
-                    subject: "[Build#${build_id} Nightly CORTX Performance CI ${currentBuild.currentResult}] : ${env.JOB_NAME}",
+                    subject: "Build#${build_id} Nightly CORTX Performance CI ${currentBuild.currentResult}",
                     attachLog: true,
                     to: "${mailRecipients}",
                     recipientProviders: recipientProvidersClass

--- a/jenkins/performance-ci/nightly-performance-ci.groovy
+++ b/jenkins/performance-ci/nightly-performance-ci.groovy
@@ -137,7 +137,7 @@ pipeline {
 
                 // Email Notification
                 if ( params.EMAIL_RECIPIENTS == "DEVOPS" && currentBuild.result == "SUCCESS" ) {
-                    mailRecipients = "CORTX.DevOps.RE@seagate.com"
+                    mailRecipients = "CORTX.DevOps.RE@seagate.com, CORTX.Perf@seagate.com"
                 }
                 else if ( params.EMAIL_RECIPIENTS == "DEBUG" ) {
                     mailRecipients = "shailesh.vaidya@seagate.com"

--- a/jenkins/performance-ci/nightly-performance-ci.groovy
+++ b/jenkins/performance-ci/nightly-performance-ci.groovy
@@ -114,7 +114,7 @@ pipeline {
                 // Jenkins Summary
                 clusterStatus = ""
                 if ( currentBuild.currentResult == "SUCCESS" ) {
-                    clusterStatus = readFile(file: '$WORKSPACE/perf_sanity_stats.txt')
+                    clusterStatus = readFile(file: 'perf_sanity_stats.txt')
                     MESSAGE = "Build#${build_id} Nightly CORTX Performance CI Success"
                     ICON = "accept.gif"
                     STATUS = "SUCCESS"

--- a/jenkins/performance-ci/nightly-performance-ci.groovy
+++ b/jenkins/performance-ci/nightly-performance-ci.groovy
@@ -146,7 +146,6 @@ pipeline {
                 env.build_stage = "${build_stage}"
                 env.cluster_status = "${clusterStatusHTML}"
                 def recipientProvidersClass = [[$class: 'RequesterRecipientProvider']]
-                mailRecipients = "shailesh.vaidya@seagate.com"
                 emailext ( 
                     body: '''${SCRIPT, template="cluster-setup-email.template"}''',
                     mimeType: 'text/html',

--- a/jenkins/performance-ci/nightly-performance-ci.groovy
+++ b/jenkins/performance-ci/nightly-performance-ci.groovy
@@ -94,6 +94,7 @@ pipeline {
                         text(name: 'primary_nodes', value: "${env.primarynodes}"),
                         text(name: 'client_nodes', value: "${client_nodes}")
                     ]
+                    copyArtifacts filter: 'artifacts/perf*    ', fingerprintArtifacts: true, flatten: true, optional: true, projectName: '/Cortx-Automation/Performance/run-performance-sanity/', selector: lastCompleted(), target: ''
                 }
             }
         }
@@ -102,18 +103,9 @@ pipeline {
     post {
 
         cleanup {
-            sh label: 'Collect Artifacts', script: '''
-            mkdir -p artifacts
-            pushd scripts/performance
-                echo $client_nodes | tr ' ' '\n' > client_nodes
-                CLIENT_NODES_FILE=$PWD/client_nodes
-                CLIENT_NODE=$(head -1 "$CLIENT_NODES_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
-                scp -q "$CLIENT_NODE":/var/tmp/perf* $WORKSPACE/artifacts/
-            popd 
-            '''
             script {
                 // Archive Deployment artifacts in jenkins build
-                archiveArtifacts artifacts: "artifacts/*.*", onlyIfSuccessful: false, allowEmptyArchive: true 
+                archiveArtifacts artifacts: "*.*", onlyIfSuccessful: false, allowEmptyArchive: true 
             }
         }
     }

--- a/jenkins/performance-ci/nightly-performance-ci.groovy
+++ b/jenkins/performance-ci/nightly-performance-ci.groovy
@@ -136,6 +136,13 @@ pipeline {
                 manager.createSummary("${ICON}").appendText("<h3>Nightly CORTX Performance CI ${currentBuild.currentResult} </h3><p>Please check <a href=\"${BUILD_URL}/console\">Performance Sanity Execution logs</a> for more info <h4>Sanity Execution Logs:</h4>${clusterStatusHTML}", false, false, false, "red")
 
                 // Email Notification
+                if ( params.EMAIL_RECIPIENTS == "DEVOPS" && currentBuild.result == "SUCCESS" ) {
+                    mailRecipients = "CORTX.DevOps.RE@seagate.com"
+                }
+                else if ( params.EMAIL_RECIPIENTS == "DEBUG" ) {
+                    mailRecipients = "shailesh.vaidya@seagate.com"
+                }
+
                 env.build_stage = "${build_stage}"
                 env.cluster_status = "${clusterStatusHTML}"
                 def recipientProvidersClass = [[$class: 'RequesterRecipientProvider']]

--- a/jenkins/performance-ci/performance-sanity.groovy
+++ b/jenkins/performance-ci/performance-sanity.groovy
@@ -60,7 +60,6 @@ pipeline {
                     CLIENT_NODES_FILE=$PWD/client_nodes
                     CLIENT_NODE=$(head -1 "$CLIENT_NODES_FILE" | awk -F[,] '{print $1}' | cut -d'=' -f2)
                     scp -q "$CLIENT_NODE":/var/tmp/perf* $WORKSPACE/artifacts/
-                    ls /tmp/workspace/Cortx-Automation/Performance/run-performance-sanity/artifacts/
                 popd 
                 '''
                 script {


### PR DESCRIPTION
# Problem Statement
- Add performance stats in the nightly email notification. Which can be further used to derive deviations. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/Performance/job/nightly-performance-ci/50/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
