### PR TITLE
CORTX-31644 removed the java-1.8.0-openjdk

### DIFF
--- a/scripts/custom-iso/custom-packages.txt
+++ b/scripts/custom-iso/custom-packages.txt
@@ -31,7 +31,6 @@ graphviz-2.30.1-21.el7.x86_64
 gssproxy-0.7.0-28.el7.x86_64
 haproxy-1.5.18-9.el7.x86_64
 hdparm-9.43-5.el7.x86_64
-java-1.8.0-openjdk-headless-1.8.0.262.b10-0.el7_8.x86_64
 javapackages-tools-3.4.1-11.el7.noarch
 lcms2-2.6-3.el7.x86_64
 libXaw-1.0.13-4.el7.x86_64

--- a/scripts/deployment/roles/vm_deployment/templates/cortx_deploy_prereq.sh.j2
+++ b/scripts/deployment/roles/vm_deployment/templates/cortx_deploy_prereq.sh.j2
@@ -31,7 +31,6 @@ trusted-host: $(echo $CORTX_RELEASE_REPO | awk -F '/' '{print $3}')
 EOF
 
 # Cortx Pre-requisites
-yum install --nogpgcheck -y java-1.8.0-openjdk-headless
 yum install --nogpgcheck -y python3 cortx-prereq sshpass
 # Pre-reqs for Provisioner
 yum install --nogpgcheck -y python36-m2crypto salt salt-master salt-minion

--- a/scripts/third-party-rpm/install-cortx-prereq.sh
+++ b/scripts/third-party-rpm/install-cortx-prereq.sh
@@ -37,9 +37,9 @@ EOF
 
 yum clean all && rm -rf /var/cache/yum
 if [ "$RPM_LOCATION" == "remote" ]; then
-    yum install java-1.8.0-openjdk-headless -y && yum install cortx-prereq -y
+    yum install cortx-prereq -y
 else
-    yum install java-1.8.0-openjdk-headless -y && yum install /root/rpmbuild/RPMS/x86_64/*.rpm -y
+    yum install /root/rpmbuild/RPMS/x86_64/*.rpm -y
 fi
 
 #Cleanup


### PR DESCRIPTION
Signed-off-by: Abhirup Ghosh <abhirup.ghosh@seagate.com>

# Problem Statement
- CORTX-31644 removed the java-1.8.0-openjdk

# Design

- [x] Bug:

Didn't removed the below file as discussed with [Shailesh Vaidya](https://jts.seagate.com/secure/ViewProfile.jspa?name=729494)

In scripts/custom-prereq/kafka/kafka.spec

https://github.com/Seagate/cortx-re/blob/c124e0fc5fddbc619fb2a279cdc66dbd58b6fabe/scripts/custom-prereq/kafka/kafka.spec#L15

 Didn't removed the below one as [Mukul Malhotra](https://jts.seagate.com/secure/ViewProfile.jspa?name=747271) has already Archived it >>[CORTX-31644: Old OVA code to Archive by mukul-seagate11 · Pull Request #1115 · Seagate/cortx-re (github.com)](https://github.com/Seagate/cortx-re/pull/1115)

In solution/ova/roles/vm-provisioner/files/provisioner.sh

https://github.com/Seagate/cortx-re/blob/c124e0fc5fddbc619fb2a279cdc66dbd58b6fabe/solutions/ova/roles/vm-provisioner/files/provisioner.sh#L18

 

As the community deployment is failing from the fork branch hence [Shailesh Vaidya](https://jts.seagate.com/secure/ViewProfile.jspa?name=729494) asked me not to remove the java-1.8.0-openjdk from below file till we find the root cause.

In docker/cortx-build/dockerfile

https://github.com/Seagate/cortx-re/blob/c124e0fc5fddbc619fb2a279cdc66dbd58b6fabe/docker/cortx-build/Dockerfile#L70

- [x]  Design:

Removing the java-1.8.0-openjdk from the below files.

In scripts/custom-iso/custom-packages.txt

https://github.com/Seagate/cortx-re/blob/c124e0fc5fddbc619fb2a279cdc66dbd58b6fabe/scripts/custom-iso/custom-packages.txt#L34

In scripts/deployment/roles/vm_deployment/templates/cortx_deploy_prereq.sh.j2

https://github.com/Seagate/cortx-re/blob/c124e0fc5fddbc619fb2a279cdc66dbd58b6fabe/scripts/deployment/roles/vm_deployment/templates/cortx_deploy_prereq.sh.j2#L34

In scripts/third-party-rpm/install-cortx-prereq.sh

https://github.com/Seagate/cortx-re/blob/c124e0fc5fddbc619fb2a279cdc66dbd58b6fabe/scripts/third-party-rpm/install-cortx-prereq.sh#L40
https://github.com/Seagate/cortx-re/blob/c124e0fc5fddbc619fb2a279cdc66dbd58b6fabe/scripts/third-party-rpm/install-cortx-prereq.sh#L42

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
- [x] Jenkins pipelines used for testing

- https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/Cortx-Automation/job/docker-image-ci/567/
- https://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/setup-kubernetes-cluster/4687/
- https://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/deploy-cortx-k8-cluster/1498/
- https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/8465/
- https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/AbhirupSpace/job/community_build_job2_/43/ ... I think we might see the job failed but the purpose of the job is to check if the community build is successful or not. So the community build is successful but there is some issue with the deployment due to which services fail to start. !n deployment is not effected by this removal of the java-1.8.0-openjdk.

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
