### PR TITLE
Ad Hoc - Nightly email notification improvements

### DIFF
--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -28,6 +28,11 @@ pipeline {
             description: 'Email Notification Recipients ',
             name: 'EMAIL_RECIPIENTS'
         )
+        choice (
+            choices: ['yes' , 'no'],
+            description: 'Push newly built Docker image to GitHub ',
+            name: 'GITHUB_PUSH'
+        )
     }
     // Please configure hosts,SNS, CORTX_SCRIPTS_REPO, CORTX_SCRIPTS_BRANCH and DIX parameter in Jenkins job configuration.
     stages {
@@ -81,9 +86,8 @@ pipeline {
         }
 
         stage('Push Image to GitHub') {
-            agent {
-                node { label 'docker-image-builder-centos-7.9.2009' }
-            }
+        when { expression { params.GITHUB_PUSH == 'yes' } }
+        agent { node { label 'docker-image-builder-centos-7.9.2009' } }
            steps {
                 sh label: 'Push Image to GitHub', script: '''                   
                    systemctl status docker
@@ -251,8 +255,15 @@ pipeline {
                 }
                 env.build_setupcortx_url = sh( script: "echo ${env.cortxcluster_build_url}/artifact/artifacts/cortx-cluster-status.txt", returnStdout: true)
                 env.host = "${env.allhost}"
-                env.build_id = "ghcr.io/seagate/cortx-rgw:${VERSION}-${BUILD_NUMBER}"
-                env.build_location = "ghcr.io/seagate/cortx-rgw:${VERSION}-${BUILD_NUMBER},ghcr.io/seagate/cortx-data:${VERSION}-${BUILD_NUMBER},ghcr.io/seagate/cortx-control:${VERSION}-${BUILD_NUMBER}"
+
+                env.cortx_rgw_id = "ghcr.io/seagate/cortx-rgw:${VERSION}-${BUILD_NUMBER}"
+                env.cortx_data_id = "ghcr.io/seagate/cortx-data:${VERSION}-${BUILD_NUMBER}"
+                env.cortx_control_id = "ghcr.io/seagate/cortx-control:${VERSION}-${BUILD_NUMBER}"
+
+                env.cortx_rgw_location = "ghcr.io/seagate/cortx-rgw:${VERSION}-${BUILD_NUMBER}"
+                env.cortx_data_location = "ghcr.io/seagate/cortx-data:${VERSION}-${BUILD_NUMBER}"
+                env.cortx_control_location = "ghcr.io/seagate/cortx-control:${VERSION}-${BUILD_NUMBER}"
+
                 env.deployment_status = "${MESSAGE}"
                 env.cluster_status = "${env.build_setupcortx_url}"
                 env.cortx_script_branch = "${CORTX_SCRIPTS_BRANCH}"
@@ -284,7 +295,7 @@ pipeline {
                 catchError(stageResult: 'FAILURE') {
                     archiveArtifacts allowEmptyArchive: true, artifacts: 'log/*report.xml, log/*report.html, support_bundle/*.tar, crash_files/*.gz, CHANGESET.txt', followSymlinks: false
                     emailext (
-                        body: '''${SCRIPT, template="K8s-deployment-email_3.template"}${SCRIPT, template="REL_QA_SANITY_CUS_EMAIL_7.template"}''',
+                        body: '''${SCRIPT, template="K8s-deployment-email_4.template"}${SCRIPT, template="REL_QA_SANITY_CUS_EMAIL_7.template"}''',
                         mimeType: 'text/html',
                         subject: "${MESSAGE}",
                         to: "${mailRecipients}",


### PR DESCRIPTION
# Problem Statement
- Improve nightly build email notification - 

-    Print all images with symlink to GHCR
-    Make GitHub Image push optional so that we can run nightly suit on custom images if required. 
-    Replaced `cluster status` to `Cluster Status`
-    Add symlink for K8s tag version

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
