### PR TITLE
CORTX-33695 Update service name in performance-ci

### DIFF
--- a/scripts/performance/_run-performace-tests-functions.sh
+++ b/scripts/performance/_run-performace-tests-functions.sh
@@ -50,7 +50,7 @@ function create_endpoint_url() {
     echo SOLUTION_FILE=$SOLUTION_FILE
     ACCESS_KEY=$(yq e '.solution.common.s3.default_iam_users.auth_admin' $SOLUTION_FILE)
     SECRET_KEY=$(kubectl get secrets/cortx-secret  --template={{.data.s3_auth_admin_secret}} | base64 -d)
-    HTTP_PORT=$(kubectl get svc cortx-io-svc-0 -o=jsonpath='{.spec.ports[?(@.port==80)].nodePort}')
+    HTTP_PORT=$(kubectl get svc cortx-server-0 -o=jsonpath='{.spec.ports[?(@.port==80)].nodePort}')
     if [ $(systemd-detect-virt -v) == "none" ];then
         CLUSTER_TYPE=HW 
 	    IP_ADDRESS=$(ifconfig eno5 | grep inet -w | awk '{print $2}')


### PR DESCRIPTION
# Problem Statement
- Service name is updated from `cortx-io-svc-0` to `cortx-server-0`. Incorporated this change in performance-ci

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/Performance/job/run-performance-sanity/263/console 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
