### PR TITLE
CORTX-34001: Fix logic to fetch image id for GitHub release

### DIFF
--- a/scripts/release_support/create-cortx-github-release.sh
+++ b/scripts/release_support/create-cortx-github-release.sh
@@ -44,7 +44,7 @@ fi
 # function to fetch container id of latest container image
 function get_container_id {
     cortx_container="$1"
-    container_id=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" https://api.github.com/orgs/seagate/packages/container/$cortx_container/versions | jq '.[] | select(.metadata.container.tags[]=="2.0.0-latest") | .id')
+    container_id=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" https://api.github.com/orgs/seagate/packages/container/$cortx_container/versions | jq ".[] | select(.metadata.container.tags[]==\"$TAG\") | .id")
     echo "$container_id"
 }
 

--- a/scripts/release_support/create-cortx-github-release.sh
+++ b/scripts/release_support/create-cortx-github-release.sh
@@ -26,7 +26,7 @@ SERVICES_VERSION_TITLE="**CORTX Services Release**: "
 CORTX_IMAGE_TITLE="**CORTX Container Images**: "
 CHANGESET_TITLE="**Changeset**: "
 # get args
-while getopts :t:v:c: option
+while getopts :t:v:c:r: option
 do
         case "${option}"
                 in


### PR DESCRIPTION
# Problem Statement
- GitHub release script trying to fetch latest image id, which does not work if we need to release old image.

# Design
- Update `2.0.0-latest` tag to image tag which is getting released to fetch image id.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/Release-Process/job/Create-GitHub-Release/97/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
