### PR TITLE
CORTX-33977 Adapting Newly tuned Resource limit values in RE Deployment Job

### DIFF
--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -153,7 +153,7 @@ function update_solution_config(){
         yq e -i '.solution.common.resource_allocation.hare.hax.resources.requests.memory = "256Mi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.hare.hax.resources.requests.cpu = "400m"' solution.yaml
         yq e -i '.solution.common.resource_allocation.hare.hax.resources.limits.memory = "768Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.hare.hax.resources.limits.cpu = "1200m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.hare.hax.resources.limits.cpu = "800m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.data.motr.resources.requests.memory = "1Gi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.data.motr.resources.requests.cpu = "500m"' solution.yaml

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -128,9 +128,9 @@ function update_solution_config(){
 
         yq e -i '.solution.common.resource_allocation.consul.server.storage = "10Gi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.consul.server.resources.requests.memory = "1Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.server.resources.requests.cpu = "500m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.server.resources.limits.memory = "1Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.server.resources.limits.cpu = "1000m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.server.resources.requests.cpu = "300m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.server.resources.limits.memory = "2Gi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.server.resources.limits.cpu = "500m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.consul.client.resources.requests.memory = "256Mi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.consul.client.resources.requests.cpu = "200m"' solution.yaml

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -127,67 +127,68 @@ function update_solution_config(){
         control_external_nodeport=$CONTROL_EXTERNAL_NODEPORT yq e -i '.solution.common.external_services.control.nodePorts.https = env(control_external_nodeport)' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.consul.server.storage = "10Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.server.resources.requests.memory = "200Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.server.resources.requests.cpu = "200m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.server.resources.limits.memory = "500Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.server.resources.limits.cpu = "500m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.client.resources.requests.memory = "200Mi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.server.resources.requests.memory = "1Gi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.server.resources.requests.cpu = "500m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.server.resources.limits.memory = "1Gi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.server.resources.limits.cpu = "1000m"' solution.yaml
+
+        yq e -i '.solution.common.resource_allocation.consul.client.resources.requests.memory = "256Mi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.consul.client.resources.requests.cpu = "200m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.client.resources.limits.memory = "500Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.consul.client.resources.limits.cpu = "500m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.client.resources.limits.memory = "512Mi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.consul.client.resources.limits.cpu = "300m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.zookeeper.storage_request_size = "8Gi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.zookeeper.data_log_dir_request_size = "8Gi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.zookeeper.resources.requests.memory = "256Mi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.zookeeper.resources.requests.cpu = "250m"' solution.yaml
         yq e -i '.solution.common.resource_allocation.zookeeper.resources.limits.memory = "1Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.zookeeper.resources.limits.cpu = "1000m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.zookeeper.resources.limits.cpu = "300m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.kafka.storage_request_size = "8Gi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.kafka.resources.requests.memory = "1Gi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.kafka.resources.requests.cpu = "250m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.kafka.resources.limits.memory = "3Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.kafka.resources.limits.cpu = "1000m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.kafka.resources.limits.memory = "2Gi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.kafka.resources.limits.cpu = "500m"' solution.yaml
 
-        yq e -i '.solution.common.resource_allocation.hare.hax.resources.requests.memory = "128Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.hare.hax.resources.requests.cpu = "250m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.hare.hax.resources.limits.memory = "2Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.hare.hax.resources.limits.cpu = "1000m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.hare.hax.resources.requests.memory = "256Mi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.hare.hax.resources.requests.cpu = "400m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.hare.hax.resources.limits.memory = "768Mi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.hare.hax.resources.limits.cpu = "1200m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.data.motr.resources.requests.memory = "1Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.data.motr.resources.requests.cpu = "250m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.data.motr.resources.requests.cpu = "500m"' solution.yaml
         yq e -i '.solution.common.resource_allocation.data.motr.resources.limits.memory = "2Gi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.data.motr.resources.limits.cpu = "1000m"' solution.yaml
 
-        yq e -i '.solution.common.resource_allocation.data.confd.resources.requests.memory = "128Mi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.data.confd.resources.requests.memory = "256Mi"' solution.yaml
         yq e -i '.solution.common.resource_allocation.data.confd.resources.requests.cpu = "250m"' solution.yaml
         yq e -i '.solution.common.resource_allocation.data.confd.resources.limits.memory = "512Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.data.confd.resources.limits.cpu = "500m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.data.confd.resources.limits.cpu = "400m"' solution.yaml
 
-        yq e -i '.solution.common.resource_allocation.server.rgw.resources.requests.memory = "128Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.server.rgw.resources.requests.cpu = "250m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.server.rgw.resources.requests.memory = "1Gi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.server.rgw.resources.requests.cpu = "500m"' solution.yaml
         yq e -i '.solution.common.resource_allocation.server.rgw.resources.limits.memory = "2Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.server.rgw.resources.limits.cpu = "2000m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.server.rgw.resources.limits.cpu = "1500m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.control.agent.resources.requests.memory = "128Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.control.agent.resources.requests.cpu = "250m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.control.agent.resources.requests.cpu = "200m"' solution.yaml
         yq e -i '.solution.common.resource_allocation.control.agent.resources.limits.memory = "256Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.control.agent.resources.limits.cpu = "500m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.control.agent.resources.limits.cpu = "250m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.ha.fault_tolerance.resources.requests.memory = "128Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.fault_tolerance.resources.requests.cpu = "250m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.fault_tolerance.resources.limits.memory = "1Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.fault_tolerance.resources.limits.cpu = "500m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.fault_tolerance.resources.requests.cpu = "200m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.fault_tolerance.resources.limits.memory = "512Mi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.fault_tolerance.resources.limits.cpu = "250m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.ha.health_monitor.resources.requests.memory = "128Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.health_monitor.resources.requests.cpu = "250m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.health_monitor.resources.limits.memory = "1Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.health_monitor.resources.limits.cpu = "500m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.health_monitor.resources.requests.cpu = "200m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.health_monitor.resources.limits.memory = "512Mi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.health_monitor.resources.limits.cpu = "250m"' solution.yaml
 
         yq e -i '.solution.common.resource_allocation.ha.k8s_monitor.resources.requests.memory = "128Mi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.k8s_monitor.resources.requests.cpu = "250m"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.k8s_monitor.resources.limits.memory = "1Gi"' solution.yaml
-        yq e -i '.solution.common.resource_allocation.ha.k8s_monitor.resources.limits.cpu = "500m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.k8s_monitor.resources.requests.cpu = "200m"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.k8s_monitor.resources.limits.memory = "512Mi"' solution.yaml
+        yq e -i '.solution.common.resource_allocation.ha.k8s_monitor.resources.limits.cpu = "250m"' solution.yaml
 
         yq e -i '.solution.storage_sets[0].name = "storage-set-1"' solution.yaml
         sns=$SNS_CONFIG yq e -i '.solution.storage_sets[0].durability.sns = env(sns)' solution.yaml


### PR DESCRIPTION
# Problem Statement
-  Modify resource limits as requested in CORTX-33977 .  Auto-generated solution.yaml is added below and is tested at - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/11522/artifact/artifacts/solution.yaml/*view*/

```
solution:
  namespace: cortx
  deployment_type: standard
  secrets:
    name: cortx-secret
    content:
      kafka_admin_secret: null
      consul_admin_secret: null
      common_admin_secret: null
      s3_auth_admin_secret: ldapadmin
      csm_auth_admin_secret: null
      csm_mgmt_admin_secret: Cortxadmin@123
  images:
    consul: ghcr.io/seagate/consul:1.11.4
    kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r97
    zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9
    rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
    busybox: ghcr.io/seagate/busybox:latest
    cortxcontrol: ghcr.io/seagate/cortx-control:2.0.0-latest
    cortxdata: ghcr.io/seagate/cortx-data:2.0.0-latest
    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-latest
    cortxha: ghcr.io/seagate/cortx-control:2.0.0-latest
    cortxclient: ghcr.io/seagate/cortx-data:2.0.0-latest
  common:
    storage_provisioner_path: /mnt/fs-local-volume
    s3:
      default_iam_users:
        auth_admin: sgiamadmin
        auth_user: user_name
      max_start_timeout: 240
      instances_per_node: 1
      extra_configuration: ""
    motr:
      num_client_inst: 0
      extra_configuration: ""
    hax:
      protocol: https
      port_num: 22003
    external_services:
      s3:
        type: NodePort
        count: 1
        ports:
          http: 80
          https: 443
        nodePorts:
          http: 30080
          https: 30443
      control:
        type: NodePort
        ports:
          https: 8081
        nodePorts:
          https: 31169
    resource_allocation:
      consul:
        server:
          storage: 10Gi
          resources:
            requests:
              memory: 1Gi
              cpu: 300m
            limits:
              memory: 2Gi
              cpu: 500m
        client:
          resources:
            requests:
              memory: 256Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 300m
      zookeeper:
        storage_request_size: 8Gi
        data_log_dir_request_size: 8Gi
        resources:
          requests:
            memory: 256Mi
            cpu: 250m
          limits:
            memory: 1Gi
            cpu: 300m
      kafka:
        storage_request_size: 8Gi
        resources:
          requests:
            memory: 1Gi
            cpu: 250m
          limits:
            memory: 2Gi
            cpu: 500m
      hare:
        hax:
          resources:
            requests:
              memory: 256Mi
              cpu: 400m
            limits:
              memory: 768Mi
              cpu: 800m
      data:
        motr:
          resources:
            requests:
              memory: 1Gi
              cpu: 500m
            limits:
              memory: 2Gi
              cpu: 1000m
        confd:
          resources:
            requests:
              memory: 256Mi
              cpu: 250m
            limits:
              memory: 512Mi
              cpu: 400m
      server:
        rgw:
          resources:
            requests:
              memory: 1Gi
              cpu: 500m
            limits:
              memory: 2Gi
              cpu: 1500m
      control:
        agent:
          resources:
            requests:
              memory: 128Mi
              cpu: 200m
            limits:
              memory: 256Mi
              cpu: 250m
      ha:
        fault_tolerance:
          resources:
            requests:
              memory: 128Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 250m
        health_monitor:
          resources:
            requests:
              memory: 128Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 250m
        k8s_monitor:
          resources:
            requests:
              memory: 128Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 250m
  storage_sets:
    - name: storage-set-1
      durability:
        sns: 3+2+0
        dix: 1+2+0
      container_group_size: "1"
      storage:
        - name: cvg-01
          type: ios
          devices:
            metadata:
              - path: /dev/sdc
                size: 25Gi
            data:
              - path: /dev/sdd
                size: 25Gi
              - path: /dev/sde
                size: 25Gi
        - name: cvg-02
          type: ios
          devices:
            metadata:
              - path: /dev/sdf
                size: 25Gi
            data:
              - path: /dev/sdg
                size: 25Gi
              - path: /dev/sdh
                size: 25Gi
      nodes:
        - ssc-vm-rhev4-1890.colo.seagate.com
        - ssc-vm-rhev4-1942.colo.seagate.com
        - ssc-vm-rhev4-1943.colo.seagate.com
        - ssc-vm-rhev4-1944.colo.seagate.com
        - ssc-vm-rhev4-1945.colo.seagate.com
```

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/11482/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
