### PR TITLE
CORTX-33968: Add GitHub Action pr-title-checker

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,15 @@
+{
+    "LABEL": {
+      "name": "Check Failed - PR Title",
+      "color": "EEEEEE"
+    },
+    "CHECKS": {
+      "prefixes": ["COMMUNITY: "],
+      "regexp": "CORTX-[0-9]{5}: "
+    },
+    "MESSAGES": {
+      "success": "PR Title Verified Successfully",
+      "failure": "Failed to verify PR title",
+      "notice": ""
+    }
+}

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,17 @@
+name: "PR Title Checker"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Seagate/pr-title-checker@v1.3.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

# Problem Statement
- pull request should contain JIRA ID or `COMMUNITY: ` at start of PR title. most of the times, developers do not follow this rule and main branch commit history does not look firm with commit messages which in turn do not generate good changelog.  

# Design
-  Setup a GitHub Action to check PR title for JIRA ID or `COMMUNITY: ` word. if not present, add failed label to PR.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [ ] Jenkins pipelines used for testing

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
