### PR TITLE
CORTX-32167: Fix broken links in custom-ci

### DIFF
--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -175,7 +175,7 @@ pipeline {
                         script { build_stage = env.STAGE_NAME }
                         script {
                             try {
-                                def motrbuild = build job: 'Release_Engineering/re-workspace/motr-custom-build/', wait: true,
+                                def motrbuild = build job: 'GitHub-custom-ci-builds/generic/motr-custom-build/', wait: true,
                                         parameters: [
                                                         string(name: 'MOTR_URL', value: "${MOTR_URL}"),
                                                         string(name: 'MOTR_BRANCH', value: "${MOTR_BRANCH}"),

--- a/jenkins/custom-ci/generic/custom-ci.groovy
+++ b/jenkins/custom-ci/generic/custom-ci.groovy
@@ -96,7 +96,7 @@ pipeline {
 
         choice(
             name: 'BUILD_LATEST_CORTX_CC',
-                choices: ['yes', 'no'],
+                choices: ['no', 'yes'],
                 description: 'Build cortx-cc from latest code or use last-successful build.'
         )
 


### PR DESCRIPTION
# Problem Statement
- motr custom-ci link is broken

# Design
-  Fix broken link and build option for cortx-cc

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [ ] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/custom-ci-test/258/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
