### PR TITLE
CORTX-32167: Add cortx-cc in cortx images

### DIFF
--- a/docker/cortx-deploy/cortx-all/cortx-component-rpms.txt
+++ b/docker/cortx-deploy/cortx-all/cortx-component-rpms.txt
@@ -1,5 +1,6 @@
 cortx-py-utils
 cortx-hare
+cortx-cc
 cortx-motr
 cortx-csm_agent
 cortx-provisioner

--- a/docker/cortx-deploy/cortx-data/cortx-component-rpms.txt
+++ b/docker/cortx-deploy/cortx-data/cortx-component-rpms.txt
@@ -1,4 +1,5 @@
 cortx-motr
 cortx-hare
+cortx-cc
 cortx-py-utils
 cortx-provisioner

--- a/docker/cortx-deploy/cortx-rgw/cortx-component-rpms.txt
+++ b/docker/cortx-deploy/cortx-rgw/cortx-component-rpms.txt
@@ -1,5 +1,6 @@
 cortx-motr
 cortx-hare
+cortx-cc
 cortx-py-utils
 cortx-provisioner
 cortx-rgw-integration


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

# Problem Statement
- cortx-cc component is not part of cortx-images
# Design
-  Add cortx-cc component in cortx images

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing
    custom-ci - https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/custom-ci-test/260/
    image generation - https://eos-jenkins.colo.seagate.com/job/GitHub-custom-ci-builds/job/generic/job/cortx-all-docker-image/2460/
    deployment - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/12002/ 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
