### PR TITLE
CORTX-33243:  Add support for log device 

### DIFF
--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -201,8 +201,8 @@ function update_solution_config(){
         yq e -i '.solution.storage_sets[0].storage[0].devices.metadata[0].size = "25Gi"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[0].devices.data[0].path = "/dev/sdd"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[0].devices.data[0].size = "25Gi"' solution.yaml
-        yq e -i '.solution.storage_sets[0].storage[0].devices.data[1].path = "/dev/sde"' solution.yaml
-        yq e -i '.solution.storage_sets[0].storage[0].devices.data[1].size = "25Gi"' solution.yaml
+        yq e -i '.solution.storage_sets[0].storage[0].devices.log[0].path = "/dev/sde"' solution.yaml
+        yq e -i '.solution.storage_sets[0].storage[0].devices.log[0].size = "25Gi"' solution.yaml
        
         yq e -i '.solution.storage_sets[0].storage[1].name = "cvg-02"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[1].type = "ios"' solution.yaml
@@ -210,8 +210,8 @@ function update_solution_config(){
         yq e -i '.solution.storage_sets[0].storage[1].devices.metadata[0].size = "25Gi"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[1].devices.data[0].path = "/dev/sdg"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[1].devices.data[0].size = "25Gi"' solution.yaml
-        yq e -i '.solution.storage_sets[0].storage[1].devices.data[1].path = "/dev/sdh"' solution.yaml
-        yq e -i '.solution.storage_sets[0].storage[1].devices.data[1].size = "25Gi"' solution.yaml
+        yq e -i '.solution.storage_sets[0].storage[1].devices.log[0].path = "/dev/sdh"' solution.yaml
+        yq e -i '.solution.storage_sets[0].storage[1].devices.log[0].size = "25Gi"' solution.yaml
     popd
 }        
 

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -202,7 +202,7 @@ function update_solution_config(){
         yq e -i '.solution.storage_sets[0].storage[0].devices.data[0].path = "/dev/sdd"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[0].devices.data[0].size = "25Gi"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[0].devices.log[0].path = "/dev/sde"' solution.yaml
-        yq e -i '.solution.storage_sets[0].storage[0].devices.log[0].size = "25Gi"' solution.yaml
+        yq e -i '.solution.storage_sets[0].storage[0].devices.log[0].size = "4Gi"' solution.yaml
        
         yq e -i '.solution.storage_sets[0].storage[1].name = "cvg-02"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[1].type = "ios"' solution.yaml
@@ -211,7 +211,7 @@ function update_solution_config(){
         yq e -i '.solution.storage_sets[0].storage[1].devices.data[0].path = "/dev/sdg"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[1].devices.data[0].size = "25Gi"' solution.yaml
         yq e -i '.solution.storage_sets[0].storage[1].devices.log[0].path = "/dev/sdh"' solution.yaml
-        yq e -i '.solution.storage_sets[0].storage[1].devices.log[0].size = "25Gi"' solution.yaml
+        yq e -i '.solution.storage_sets[0].storage[1].devices.log[0].size = "4Gi"' solution.yaml
     popd
 }        
 


### PR DESCRIPTION
# Problem Statement
- Added support for mandatory log device support in solution.yaml for DevOps CI/CD pipelines.  For standard VM specification following solution.yaml will be auto-generated

```
solution:
  namespace: cortx
  deployment_type: standard
  secrets:
    name: cortx-secret
    content:
      kafka_admin_secret: null
      consul_admin_secret: null
      common_admin_secret: null
      s3_auth_admin_secret: ldapadmin
      csm_auth_admin_secret: null
      csm_mgmt_admin_secret: Cortxadmin@123
  images:
    consul: ghcr.io/seagate/consul:1.11.4
    kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r97
    zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9
    rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
    busybox: ghcr.io/seagate/busybox:latest
    cortxcontrol: ghcr.io/seagate/cortx-control:2.0.0-940
    cortxdata: ghcr.io/seagate/cortx-data:2.0.0-940
    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-940
    cortxha: ghcr.io/seagate/cortx-control:2.0.0-940
    cortxclient: ghcr.io/seagate/cortx-data:2.0.0-940
  common:
    storage_provisioner_path: /mnt/fs-local-volume
    s3:
      default_iam_users:
        auth_admin: sgiamadmin
        auth_user: user_name
      max_start_timeout: 240
      instances_per_node: 1
      extra_configuration: ""
    motr:
      num_client_inst: 0
      extra_configuration: ""
    hax:
      protocol: https
      port_num: 22003
    external_services:
      s3:
        type: NodePort
        count: 1
        ports:
          http: 80
          https: 443
        nodePorts:
          http: 30080
          https: 30443
      control:
        type: NodePort
        ports:
          https: 8081
        nodePorts:
          https: 31169
    resource_allocation:
      consul:
        server:
          storage: 10Gi
          resources:
            requests:
              memory: 1Gi
              cpu: 300m
            limits:
              memory: 2Gi
              cpu: 500m
        client:
          resources:
            requests:
              memory: 256Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 300m
      zookeeper:
        storage_request_size: 8Gi
        data_log_dir_request_size: 8Gi
        resources:
          requests:
            memory: 256Mi
            cpu: 250m
          limits:
            memory: 1Gi
            cpu: 300m
      kafka:
        storage_request_size: 8Gi
        resources:
          requests:
            memory: 1Gi
            cpu: 250m
          limits:
            memory: 2Gi
            cpu: 500m
      hare:
        hax:
          resources:
            requests:
              memory: 256Mi
              cpu: 300m
            limits:
              memory: 768Mi
              cpu: 500m
      data:
        motr:
          resources:
            requests:
              memory: 1Gi
              cpu: 500m
            limits:
              memory: 2Gi
              cpu: 1000m
        confd:
          resources:
            requests:
              memory: 256Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 300m
      server:
        rgw:
          resources:
            requests:
              memory: 1Gi
              cpu: 500m
            limits:
              memory: 2Gi
              cpu: 1500m
      control:
        agent:
          resources:
            requests:
              memory: 128Mi
              cpu: 200m
            limits:
              memory: 256Mi
              cpu: 250m
      ha:
        fault_tolerance:
          resources:
            requests:
              memory: 128Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 250m
        health_monitor:
          resources:
            requests:
              memory: 128Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 250m
        k8s_monitor:
          resources:
            requests:
              memory: 128Mi
              cpu: 200m
            limits:
              memory: 512Mi
              cpu: 250m
  storage_sets:
    - name: storage-set-1
      durability:
        sns: 1+0+0
        dix: 1+0+0
      container_group_size: "1"
      storage:
        - name: cvg-01
          type: ios
          devices:
            metadata:
              - path: /dev/sdc
                size: 25Gi
            data:
              - path: /dev/sdd
                size: 25Gi
            log:
              - path: /dev/sde
                size: 25Gi
        - name: cvg-02
          type: ios
          devices:
            metadata:
              - path: /dev/sdf
                size: 25Gi
            data:
              - path: /dev/sdg
                size: 25Gi
            log:
              - path: /dev/sdh
                size: 25Gi
      nodes:
        - ssc-vm-rhev4-2983.colo.seagate.com
        - ssc-vm-rhev4-2984.colo.seagate.com
        - ssc-vm-rhev4-2985.colo.seagate.com
```

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/12361

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
