### PR TITLE
CORTX-34239: Removed container image metadata fetch using ContainerConfig

### DIFF
--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -8,7 +8,7 @@ pipeline {
     options {
         timeout(time: 600, unit: 'MINUTES')
         timestamps()
-        buildDiscarder(logRotator(daysToKeepStr: '20', numToKeepStr: '20'))
+        buildDiscarder(logRotator(daysToKeepStr: '35', numToKeepStr: '35'))
         disableConcurrentBuilds()
     }
     environment {

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -97,12 +97,6 @@ pipeline {
                    docker pull $CORTX_DATA_IMAGE
                    docker pull $CORTX_CONTROL_IMAGE
 
-                   echo "\n RPM Build URL used for Nightly Image"
-                   docker inspect $CORTX_SERVER_IMAGE | jq -r '.[] | (.ContainerConfig.Cmd)' | grep 'BUILD_URL='
-                   docker inspect $CORTX_DATA_IMAGE | jq -r '.[] | (.ContainerConfig.Cmd)' | grep 'BUILD_URL='
-                   docker inspect $CORTX_CONTROL_IMAGE | jq -r '.[] | (.ContainerConfig.Cmd)' | grep 'BUILD_URL='
-                   #Update VERSION details in RELEASE.INFO file
-
                    docker commit $(docker run -d ${CORTX_SERVER_IMAGE} sed -i /VERSION/s/\\"2.0.0.*\\"/\\"${VERSION}-${BUILD_NUMBER}\\"/ /opt/seagate/cortx/RELEASE.INFO) ghcr.io/seagate/cortx-rgw:${VERSION}-${BUILD_NUMBER}
                    docker commit $(docker run -d ${CORTX_DATA_IMAGE} sed -i /VERSION/s/\\"2.0.0.*\\"/\\"${VERSION}-${BUILD_NUMBER}\\"/ /opt/seagate/cortx/RELEASE.INFO) ghcr.io/seagate/cortx-data:${VERSION}-${BUILD_NUMBER}
                    docker commit $(docker run -d ${CORTX_CONTROL_IMAGE} sed -i /VERSION/s/\\"2.0.0.*\\"/\\"${VERSION}-${BUILD_NUMBER}\\"/ /opt/seagate/cortx/RELEASE.INFO) ghcr.io/seagate/cortx-control:${VERSION}-${BUILD_NUMBER} 


### PR DESCRIPTION
# Problem Statement
- We enabled DOCKER_BUILDKITas part of https://github.com/Seagate/cortx-re/pull/1220 to improve container image generation time.  
- DOCKER_BUILDKIT has disabled support for ContainerConfig. Refer  https://github.com/docker/cli/issues/2868
- We were using `ContainerConfig` in Nightly Deploy job to fetch Build URL details used in Nightly image creation. Refer - https://github.com/Seagate/cortx-re/blob/main/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy#L101 .  Hence Nightly deploy job failed due to DOCKER_BUILDKIT change. 
- Disabled printing Build URL in Nightly Deploy. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Deployment/job/Nightly-K8s-Deploy/950/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
