### PR TITLE
CORTX-34001: Fix GitHub release process

### DIFF
--- a/jenkins/release-process/github-release.groovy
+++ b/jenkins/release-process/github-release.groovy
@@ -32,8 +32,7 @@ pipeline {
                 script {
                     withCredentials([string(credentialsId: 'cortx-admin-token', variable: 'GH_TOKEN')]) {
                         github_release_info = sh( script: '''
-                            set -x
-                            ./scripts/release_support/create-cortx-github-release.sh -t "\${GIT_TAG}" -v "\${SERVICES_VERSION}" -c "\${CHANGESET_URL}" -r "\${RELEASE_REPO}"
+                            bash -x scripts/release_support/create-cortx-github-release.sh -t "\${GIT_TAG}" -v "\${SERVICES_VERSION}" -c "\${CHANGESET_URL}" -r "\${RELEASE_REPO}"
                         ''', returnStdout: true).trim()
                         env.github_release_url = github_release_info.split()[0]
                         env.tags = github_release_info.split()[1]

--- a/jenkins/release-process/github-release.groovy
+++ b/jenkins/release-process/github-release.groovy
@@ -31,9 +31,10 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 script {
                     withCredentials([string(credentialsId: 'cortx-admin-token', variable: 'GH_TOKEN')]) {
-                        github_release_info = sh( script: """
-                            bash -x scripts/release_support/create-cortx-github-release.sh -t $GIT_TAG -v $SERVICES_VERSION -c $CHANGESET_URL -r $RELEASE_REPO
-                        """, returnStdout: true).trim()
+                        github_release_info = sh( script: '''
+                            set -x
+                            ./scripts/release_support/create-cortx-github-release.sh -t "\${GIT_TAG}" -v "\${SERVICES_VERSION}" -c "\${CHANGESET_URL}" -r "\${RELEASE_REPO}"
+                        ''', returnStdout: true).trim()
                         env.github_release_url = github_release_info.split()[0]
                         env.tags = github_release_info.split()[1]
                     }			

--- a/scripts/release_support/create-cortx-github-release.sh
+++ b/scripts/release_support/create-cortx-github-release.sh
@@ -36,8 +36,8 @@ do
                 r) RELEASE_REPO="$OPTARG";;
         esac
 done
-if [[ -z "$TAG" || -z "$SERVICES_VERSION" || -z "$CHANGESET_URL" ]]; then
-        echo "Usage: git-release [-t <tag>] [-v <services-version>] [-c <changeset file url>]"
+if [[ -z "$TAG" || -z "$SERVICES_VERSION" || -z "$CHANGESET_URL" || -z "$RELEASE_REPO" ]]; then
+        echo "Usage: git-release [-t <tag>] [-v <services-version>] [-c <changeset file url>] [-r <org/repo>]"
         exit 1
 fi
 


### PR DESCRIPTION
# Problem Statement
- `-r` option in getopts was not getting called correctly in script `jenkins\release-process\github-release.groovy`

# Design
-  Updated script call 
-  Added non-zero check for `RELEASE_INFO` variable

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [ ] Jenkins pipelines used for testing

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
