### PR TITLE
CORTX-34303: Set CORTX_DEPLOY_HA_TIMEOUT as 480s to avoid deployment failure. 

### DIFF
--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -95,7 +95,7 @@ pipeline {
                         export S3_EXTERNAL_HTTP_NODEPORT=${S3_EXTERNAL_HTTP_NODEPORT}
                         export S3_EXTERNAL_HTTPS_NODEPORT=${S3_EXTERNAL_HTTPS_NODEPORT}
                         export NAMESPACE=${NAMESPACE}
-                        export CORTX_DEPLOY_HA_TIMEOUT="480"
+                        export CORTX_DEPLOY_HA_TIMEOUT="480s"
                         ./cortx-deploy.sh --cortx-cluster
                     popd
                 '''

--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -95,6 +95,7 @@ pipeline {
                         export S3_EXTERNAL_HTTP_NODEPORT=${S3_EXTERNAL_HTTP_NODEPORT}
                         export S3_EXTERNAL_HTTPS_NODEPORT=${S3_EXTERNAL_HTTPS_NODEPORT}
                         export NAMESPACE=${NAMESPACE}
+                        export CORTX_DEPLOY_HA_TIMEOUT="480"
                         ./cortx-deploy.sh --cortx-cluster
                     popd
                 '''

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -255,7 +255,7 @@ function execute_deploy_script() {
     local SCRIPT_NAME=$1
         pushd $SCRIPT_LOCATION/k8_cortx_cloud
         chmod +x *.sh
-        export CORTX_DEPLOY_NO_WAIT="true" && ./$SCRIPT_NAME
+        ./$SCRIPT_NAME
         if [ $? -eq 0 ] 
         then 
            echo -e "\nSuccessfully executed $SCRIPT_NAME." 

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -255,6 +255,7 @@ function execute_deploy_script() {
     local SCRIPT_NAME=$1
         pushd $SCRIPT_LOCATION/k8_cortx_cloud
         chmod +x *.sh
+        echo CORTX_DEPLOY_HA_TIMEOUT:$CORTX_DEPLOY_HA_TIMEOUT
         ./$SCRIPT_NAME
         if [ $? -eq 0 ] 
         then 

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -255,7 +255,7 @@ function execute_deploy_script() {
     local SCRIPT_NAME=$1
         pushd $SCRIPT_LOCATION/k8_cortx_cloud
         chmod +x *.sh
-        ./$SCRIPT_NAME
+        export CORTX_DEPLOY_NO_WAIT="true" && ./$SCRIPT_NAME
         if [ $? -eq 0 ] 
         then 
            echo -e "\nSuccessfully executed $SCRIPT_NAME." 

--- a/solutions/kubernetes/cortx-deploy-functions.sh
+++ b/solutions/kubernetes/cortx-deploy-functions.sh
@@ -255,7 +255,6 @@ function execute_deploy_script() {
     local SCRIPT_NAME=$1
         pushd $SCRIPT_LOCATION/k8_cortx_cloud
         chmod +x *.sh
-        echo CORTX_DEPLOY_HA_TIMEOUT:$CORTX_DEPLOY_HA_TIMEOUT
         ./$SCRIPT_NAME
         if [ $? -eq 0 ] 
         then 

--- a/solutions/kubernetes/cortx-deploy.sh
+++ b/solutions/kubernetes/cortx-deploy.sh
@@ -157,7 +157,7 @@ function setup_cluster() {
     fi
 
     # Deploy CORTX CLuster (deploy-cortx-cloud.sh) :
-    ssh_primary_node "/var/tmp/cortx-deploy-functions.sh --$TARGET"
+    ssh_primary_node "export CORTX_DEPLOY_HA_TIMEOUT=$CORTX_DEPLOY_HA_TIMEOUT && /var/tmp/cortx-deploy-functions.sh --$TARGET"
     add_primary_separator "\tPrint Cluster Status"
     rm -rf /var/tmp/cortx-cluster-status.txt
     ssh_primary_node "export DEPLOYMENT_METHOD=$DEPLOYMENT_METHOD && /var/tmp/cortx-deploy-functions.sh --status" | tee /var/tmp/cortx-cluster-status.txt


### PR DESCRIPTION
# Problem Statement
- Deployment is failing due to HA POD not being in running a state within default timeout. Increased timeout from 240 sec to 480 sec for HA POD deployment to avoid deployment failures.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Release_Engineering/job/re-workspace/job/sv_space/job/setup-cortx-cluster/226/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
