### PR TITLE
CORTX-34330: Nightly Build Issues

### DIFF
--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -95,7 +95,7 @@ pipeline {
                         export S3_EXTERNAL_HTTP_NODEPORT=${S3_EXTERNAL_HTTP_NODEPORT}
                         export S3_EXTERNAL_HTTPS_NODEPORT=${S3_EXTERNAL_HTTPS_NODEPORT}
                         export NAMESPACE=${NAMESPACE}
-                        export CORTX_DEPLOY_HA_TIMEOUT="480s"
+                        export CORTX_DEPLOY_HA_TIMEOUT="600s"
                         ./cortx-deploy.sh --cortx-cluster
                     popd
                 '''

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -225,7 +225,7 @@ pipeline {
                     env.sanity_result = "SKIPPED"
                     env.deployment_result = "FAILURE"
                     currentBuild.result = "FAILURE"
-                } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" ) {
+                } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" || "${env.qaSanity_status}" == "null" ) {
                     manager.buildFailure()
                     MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
                     ICON = "error.gif"
@@ -233,14 +233,6 @@ pipeline {
                     env.sanity_result = "FAILURE"
                     env.deployment_result = "SUCCESS"
                     currentBuild.result = "FAILURE"
-                } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "null" ) {
-                    manager.buildFailure()
-                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
-                    ICON = "unstable.gif"
-                    STATUS = "UNSTABLE"
-                    env.sanity_result = "SKIPPED"
-                    env.deployment_result = "SUCCESS"
-                    currentBuild.result = "UNSTABLE"    
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "UNSTABLE" ) {
                     MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
                     ICON = "unstable.gif"

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -18,8 +18,8 @@ pipeline {
         last_success_build_number = getBuild(JOB_URL)
     }
     parameters {
-        string(name: 'CORTX_RE_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for Cluster Setup scripts', trim: true)
-        string(name: 'CORTX_RE_REPO', defaultValue: 'https://github.com/Seagate/cortx-re', description: 'Repository for Cluster Setup scripts', trim: true)
+        string(name: 'CORTX_RE_BRANCH', defaultValue: 'nightly-build-fix-1', description: 'Branch or GitHash for Cluster Setup scripts', trim: true)
+        string(name: 'CORTX_RE_REPO', defaultValue: 'https://github.com/shailesh-vaidya/cortx-re', description: 'Repository for Cluster Setup scripts', trim: true)
         string(name: 'CORTX_SERVER_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-rgw:2.0.0-latest', description: 'CORTX-SERVER image', trim: true)
         string(name: 'CORTX_DATA_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-latest', description: 'CORTX-DATA image', trim: true)
         string(name: 'CORTX_CONTROL_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-control:2.0.0-latest', description: 'CORTX-CONTROL image', trim: true)

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -279,10 +279,10 @@ pipeline {
                     //mailRecipients = "cortx.sme@seagate.com, manoj.management.team@seagate.com, CORTX.SW.Architecture.Team@seagate.com, CORTX.DevOps.RE@seagate.com"
                 }
                 else if ( params.EMAIL_RECIPIENTS == "ALL" && currentBuild.result == "UNSTABLE" ) {
-                    mailRecipients = "Cortx.Perf@seagate.com, cortx-cicd@seagate.com"
+                    mailRecipients = "Cortx.Perf@seagate.com,  CORTX.DevOps.RE@seagate.com"
                 }
                 else if ( params.EMAIL_RECIPIENTS == "ALL" && currentBuild.result == "FAILURE" ) {
-                    mailRecipients = "cortx-cicd@seagate.com"
+                    mailRecipients = " CORTX.DevOps.RE@seagate.com"
                 }
                 else if ( params.EMAIL_RECIPIENTS == "DEVOPS" && currentBuild.result == "SUCCESS" ) {
                     mailRecipients = "CORTX.All@seagate.com, CORTX.DevOps.RE@seagate.com"

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -225,7 +225,7 @@ pipeline {
                     env.sanity_result = "SKIPPED"
                     env.deployment_result = "FAILURE"
                     currentBuild.result = "FAILURE"
-                } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" || "${env.qaSanity_status}" == "null" ) {
+                } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "FAILURE" ) {
                     manager.buildFailure()
                     MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
                     ICON = "error.gif"
@@ -233,6 +233,14 @@ pipeline {
                     env.sanity_result = "FAILURE"
                     env.deployment_result = "SUCCESS"
                     currentBuild.result = "FAILURE"
+                } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "null" ) {
+                    manager.buildFailure()
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
+                    ICON = "unstable.gif"
+                    STATUS = "UNSTABLE"
+                    env.sanity_result = "SKIPPED"
+                    env.deployment_result = "SUCCESS"
+                    currentBuild.result = "UNSTABLE"    
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "UNSTABLE" ) {
                     MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
                     ICON = "unstable.gif"

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -207,7 +207,7 @@ pipeline {
         always {
             script {
                 junit allowEmptyResults: true, testResults: '*report.xml'
-                qaSanity_status = "SKIPPED"
+                env.qaSanity_status = "SKIPPED"
                 echo "${env.cortxCluster_status}"
                 echo "${env.qaSanity_status}"
                 env.changeset_log_url = sh( script: "echo ${env.changeset_log_url}artifact/CHANGESET.md/*view*/", returnStdout: true)

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -136,6 +136,7 @@ pipeline {
         }
 
         stage ("K8s QA Sanity") {
+            when { expression { false } }
             steps {
                 script {
                     catchError(stageResult: 'FAILURE') {

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -207,6 +207,7 @@ pipeline {
         always {
             script {
                 junit allowEmptyResults: true, testResults: '*report.xml'
+                qaSanity_status = "SKIPPED"
                 echo "${env.cortxCluster_status}"
                 echo "${env.qaSanity_status}"
                 env.changeset_log_url = sh( script: "echo ${env.changeset_log_url}artifact/CHANGESET.md/*view*/", returnStdout: true)
@@ -240,6 +241,13 @@ pipeline {
                     env.deployment_result = "SUCCESS"
                     env.sanity_result = "UNSTABLE"
                     currentBuild.result = "UNSTABLE"
+                } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "SKIPPED" ) {
+                    MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
+                    ICON = "unstable.gif"
+                    STATUS = "UNSTABLE"
+                    env.deployment_result = "SUCCESS"
+                    env.sanity_result = "SKIPPED"
+                    currentBuild.result = "UNSTABLE"    
                 } else {
                     MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=unstable, SanityTest=unstable, Regression=unstable"
                     ICON = "unstable.gif"

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -246,13 +246,13 @@ pipeline {
                 } else if ( "${env.cortxCluster_status}" == "SUCCESS" && "${env.qaSanity_status}" == "SKIPPED" ) {
                     MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=Passed, SanityTest=${env.Sanity_status}, Regression=${env.Regression_overall_status}"
                     ICON = "unstable.gif"
-                    STATUS = "UNSTABLE"
+                    STATUS = "SUCCESS"
                     env.deployment_result = "SUCCESS"
                     env.sanity_result = "SKIPPED"
-                    currentBuild.result = "UNSTABLE"    
+                    currentBuild.result = "SUCCESS"    
                 } else {
                     MESSAGE = "K8s Build#${build_id} ${env.numberofnodes}Node Deployment Deployment=unstable, SanityTest=unstable, Regression=unstable"
-                    ICON = "unstable.gif"
+                    ICON = "accept.gif"
                     STATUS = "UNSTABLE"
                     env.sanity_result = "UNSTABLE"
                     env.deployment_result = "UNSTABLE"

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -208,6 +208,8 @@ pipeline {
             script {
                 junit allowEmptyResults: true, testResults: '*report.xml'
                 env.qaSanity_status = "SKIPPED"
+                env.Sanity_status = "SKIPPED"
+                env.Regression_overall_status = "SKIPPED"
                 echo "${env.cortxCluster_status}"
                 echo "${env.qaSanity_status}"
                 env.changeset_log_url = sh( script: "echo ${env.changeset_log_url}artifact/CHANGESET.md/*view*/", returnStdout: true)

--- a/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-deploy.groovy
@@ -18,8 +18,8 @@ pipeline {
         last_success_build_number = getBuild(JOB_URL)
     }
     parameters {
-        string(name: 'CORTX_RE_BRANCH', defaultValue: 'nightly-build-fix-1', description: 'Branch or GitHash for Cluster Setup scripts', trim: true)
-        string(name: 'CORTX_RE_REPO', defaultValue: 'https://github.com/shailesh-vaidya/cortx-re', description: 'Repository for Cluster Setup scripts', trim: true)
+        string(name: 'CORTX_RE_BRANCH', defaultValue: 'main', description: 'Branch or GitHash for Cluster Setup scripts', trim: true)
+        string(name: 'CORTX_RE_REPO', defaultValue: 'https://github.com/Seagate/cortx-re', description: 'Repository for Cluster Setup scripts', trim: true)
         string(name: 'CORTX_SERVER_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-rgw:2.0.0-latest', description: 'CORTX-SERVER image', trim: true)
         string(name: 'CORTX_DATA_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-latest', description: 'CORTX-DATA image', trim: true)
         string(name: 'CORTX_CONTROL_IMAGE', defaultValue: 'cortx-docker.colo.seagate.com/seagate/cortx-control:2.0.0-latest', description: 'CORTX-CONTROL image', trim: true)


### PR DESCRIPTION
# Problem Statement
- Addressed following nightly build issues - 

    -  Skipped Sanity and Regression suite. 
    -  Removed CORTX CICD <cortx-cicd@seagate.com> alias from failure email notification.
    - Increased HA pod timeout to 10mins.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Deployment/job/Nightly-K8s-Deploy/989/ 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
