### PR TITLE
CORTX-34342: Disabled schedule from nightly-perfline-perf

### DIFF
--- a/jenkins/internal-ci/generic/nightly/nightly-perfline-performance.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-perfline-performance.groovy
@@ -5,8 +5,6 @@ pipeline {
         }
     }
 
-    triggers { cron('30 20 * * *') }
-
     options {
         timeout(time: 1440, unit: 'MINUTES')
         timestamps()

--- a/jenkins/internal-ci/generic/nightly/nightly-perfline-performance.groovy
+++ b/jenkins/internal-ci/generic/nightly/nightly-perfline-performance.groovy
@@ -140,7 +140,7 @@ pipeline {
                     mailRecipients = "Motr4-Scrum-Team@seagate.com, CORTX.DevOps.RE@seagate.com"
                 }
                 else if ( params.EMAIL_RECIPIENTS == "DEBUG" ) {
-                    mailRecipients = "rahul.kumar@seagate.com"
+                    mailRecipients = "CORTX.DevOps.RE@seagate.com"
                 }
                 env.build_stage = "${build_stage}"
                 env.cluster_status = "${PerflineWorkloadStatusHTML}"


### PR DESCRIPTION
# Problem Statement
- Disabled schedule from nightly-perfline-perf

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Motr/job/cortx-nightly-perfline-workload/79/  (Note: Job is failing due to unavailability of nodes)

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
