### PR TITLE
CORTX-34342: Removed schedule from utils PR pipeline

### DIFF
--- a/jenkins/internal-ci/generic/pr/cortx_deployment/pyutils.groovy
+++ b/jenkins/internal-ci/generic/pr/cortx_deployment/pyutils.groovy
@@ -6,7 +6,7 @@ pipeline {
             label "docker-${OS_VERSION}-node"
         }
     }
-    triggers { cron('30 18 * * *') }
+    
     options { 
         skipDefaultCheckout()
         timeout(time: 180, unit: 'MINUTES')


### PR DESCRIPTION
# Problem Statement
-  We have CORTX Utils Nightly Jenkins pipeline scheduled to execute on the main branch. Disabled scheduled execution and only keep PR-based execution. 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Cortx-Deployment/job/Generic/job/py-utils/739/

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
