### PR TITLE
CORTX-34390: Increased HA timeout value CORTX_DEPLOY_HA_TIMEOUT to 900s

### DIFF
--- a/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
+++ b/jenkins/automation/kubernetes/setup-cortx-cluster.groovy
@@ -95,7 +95,7 @@ pipeline {
                         export S3_EXTERNAL_HTTP_NODEPORT=${S3_EXTERNAL_HTTP_NODEPORT}
                         export S3_EXTERNAL_HTTPS_NODEPORT=${S3_EXTERNAL_HTTPS_NODEPORT}
                         export NAMESPACE=${NAMESPACE}
-                        export CORTX_DEPLOY_HA_TIMEOUT="600s"
+                        export CORTX_DEPLOY_HA_TIMEOUT="900s"
                         ./cortx-deploy.sh --cortx-cluster
                     popd
                 '''


### PR DESCRIPTION
# Problem Statement
- Deployment is failing with HA Pod timeout. Increased HA timeout value CORTX_DEPLOY_HA_TIMEOUT to 900s

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/RGW/job/setup-cortx-rgw-cluster/13066/console

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
