### PR TITLE
CORTX-34403: Update Jenkins image and volumes

### DIFF
--- a/docker/jenkins/prod_jenkins/docker-compose.yaml
+++ b/docker/jenkins/prod_jenkins/docker-compose.yaml
@@ -30,7 +30,6 @@ services:
     volumes:
       - /mnt/data1/jenkins/jenkins-prod:/var/jenkins_home
       - /mnt/data1/jenkins/jenkins-prod/certs/jenkins_keystore.jks:/var/lib/jenkins/jenkins.jks
-      - /mnt/bigstorage/:/mnt/bigstorage
     environment:
       - JAVA_OPTS=-Xmx8192m
       - JENKINS_OPTS= --httpPort=-1 --httpsPort=8443 --httpsKeyStore=/var/lib/jenkins/jenkins.jks --httpsKeyStorePassword=opensource!

--- a/docker/jenkins/prod_jenkins/docker-compose.yaml
+++ b/docker/jenkins/prod_jenkins/docker-compose.yaml
@@ -21,15 +21,15 @@ version: "3"
 
 services:
   cortx-jenkins-prod:
-    image: jenkins/jenkins:lts
+    image: cortx-docker.colo.seagate.com/seagate/jenkins:2.235.5
     restart: always
     ports:
       - "80:8080"
       - "50000:50000"
       - "443:8443"
     volumes:
-      - /mnt/data1/releases/jenkins/jenkins-prod:/var/jenkins_home
-      - /mnt/data1/releases/jenkins/jenkins-prod/certs/jenkins_keystore.jks:/var/lib/jenkins/jenkins.jks
+      - /mnt/data1/jenkins/jenkins-prod:/var/jenkins_home
+      - /mnt/data1/jenkins/jenkins-prod/certs/jenkins_keystore.jks:/var/lib/jenkins/jenkins.jks
       - /mnt/bigstorage/:/mnt/bigstorage
     environment:
       - JAVA_OPTS=-Xmx8192m


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

# Problem Statement
-  Jenkins container image has a latest tag, so latest version get pulled every time which causes compatibility issue.
-  Internal volumes shifted to new NFS mount

# Design
-  Fetch Jenkins image from local private registry
-  Modify NFS mount details

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [ ] Jenkins pipelines used for testing

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
