### PR TITLE
CORTX-34532: Use local repo for installing terraform

### DIFF
--- a/jenkins/automation/vra_infra_provisioner.groovy
+++ b/jenkins/automation/vra_infra_provisioner.groovy
@@ -66,6 +66,7 @@ pipeline {
                         mv /etc/yum.repos.d/rockylinux-8.4.repo /etc/yum.repos.d/rockylinux-8.4.repo.bkp
                         yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/
                         echo 'gpgcheck = 0' >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
+                        cat /etc/yum.repos.d/fwinfra-katello2.colo*.repo
                         yum -y install terraform
                         rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
                         terraform init

--- a/jenkins/automation/vra_infra_provisioner.groovy
+++ b/jenkins/automation/vra_infra_provisioner.groovy
@@ -65,9 +65,7 @@ pipeline {
                     pushd solutions/vmware/terraform/
                         mv /etc/yum.repos.d/rockylinux-8.4.repo /etc/yum.repos.d/rockylinux-8.4.repo.bkp
                         yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/
-                        echo 'gpgcheck = 0' >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
-                        cat /etc/yum.repos.d/fwinfra-katello2.colo*.repo
-                        yum clean all && yum -y install terraform
+                        yum clean all && yum -y install terraform --nogpgcheck
                         rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
                         terraform init
                         if [ "$?" -ne 0 ]; then echo -e '\nERROR: Terraform Initialization Failed!!\n'; else echo -e '\n---SUCCESS---\n'; fi

--- a/jenkins/automation/vra_infra_provisioner.groovy
+++ b/jenkins/automation/vra_infra_provisioner.groovy
@@ -65,7 +65,7 @@ pipeline {
                     pushd solutions/vmware/terraform/
                         mv /etc/yum.repos.d/rockylinux-8.4.repo /etc/yum.repos.d/rockylinux-8.4.repo.bkp
                         yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/
-                        echo 'gpgcheck = 0 >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
+                        echo 'gpgcheck = 0' >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
                         yum -y install terraform
                         rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
                         terraform init

--- a/jenkins/automation/vra_infra_provisioner.groovy
+++ b/jenkins/automation/vra_infra_provisioner.groovy
@@ -64,7 +64,8 @@ pipeline {
                 sh label: '', script: '''
                     pushd solutions/vmware/terraform/
                         mv /etc/yum.repos.d/rockylinux-8.4.repo /etc/yum.repos.d/rockylinux-8.4.repo.bkp
-                        yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/ && echo 'gpgcheck = 0 >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
+                        yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/
+                        echo 'gpgcheck = 0 >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
                         yum -y install terraform
                         rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
                         terraform init

--- a/jenkins/automation/vra_infra_provisioner.groovy
+++ b/jenkins/automation/vra_infra_provisioner.groovy
@@ -63,7 +63,9 @@ pipeline {
                 script { build_stage = env.STAGE_NAME }
                 sh label: '', script: '''
                     pushd solutions/vmware/terraform/
-                        yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && yum -y install terraform 
+                        mv /etc/yum.repos.d/rockylinux-8.4.repo /etc/yum.repos.d/rockylinux-8.4.repo.bkp
+                        yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/ && echo "gpgcheck = 0" >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
+                        yum -y install terraform 
                         rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
                         terraform init
                         if [ "$?" -ne 0 ]; then echo -e '\nERROR: Terraform Initialization Failed!!\n'; else echo -e '\n---SUCCESS---\n'; fi

--- a/jenkins/automation/vra_infra_provisioner.groovy
+++ b/jenkins/automation/vra_infra_provisioner.groovy
@@ -67,7 +67,7 @@ pipeline {
                         yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/
                         echo 'gpgcheck = 0' >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
                         cat /etc/yum.repos.d/fwinfra-katello2.colo*.repo
-                        yum -y install terraform
+                        yum clean all && yum -y install terraform
                         rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
                         terraform init
                         if [ "$?" -ne 0 ]; then echo -e '\nERROR: Terraform Initialization Failed!!\n'; else echo -e '\n---SUCCESS---\n'; fi

--- a/jenkins/automation/vra_infra_provisioner.groovy
+++ b/jenkins/automation/vra_infra_provisioner.groovy
@@ -64,8 +64,8 @@ pipeline {
                 sh label: '', script: '''
                     pushd solutions/vmware/terraform/
                         mv /etc/yum.repos.d/rockylinux-8.4.repo /etc/yum.repos.d/rockylinux-8.4.repo.bkp
-                        yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/ && echo "gpgcheck = 0" >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
-                        yum -y install terraform 
+                        yum-config-manager --add-repo http://fwinfra-katello2.colo.seagate.com/pulp/content/FWINFRA/Development/Rocky-8-SSC/custom/HashiCorp_EL8_x86_64/HashiCorp_EL8_x86_64/ && echo 'gpgcheck = 0 >> /etc/yum.repos.d/fwinfra-katello2.colo*.repo
+                        yum -y install terraform
                         rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
                         terraform init
                         if [ "$?" -ne 0 ]; then echo -e '\nERROR: Terraform Initialization Failed!!\n'; else echo -e '\n---SUCCESS---\n'; fi


### PR DESCRIPTION
# Problem Statement
- VM provisioning through Jenkins pipeline https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/VMware-Migration/job/provision-vm was failing.  
   - IT team enabled terraform URLs in firewall 
   - Infra team added Hasicorp repo locally 
   - Infra team modified ssc-cicd-rocky88 as vmware catalog item

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
- [x] Jenkins pipelines used for testing - https://eos-jenkins.colo.seagate.com/job/Cortx-Automation/job/VMware-Migration/job/provision-vm/52/ 

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] Jira ID/ COMMUNITY is prefixed in PR title
      Prefix Syntax - 
        `CORTX-<5 digit JIRA ID>: <PR Title>` - for Seagate Employees
        `COMMUNITY: <PR Title>`  - for open source contributors
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
